### PR TITLE
WAF v1.0.15 and logger callback

### DIFF
--- a/src/helper/config.cpp
+++ b/src/helper/config.cpp
@@ -59,7 +59,7 @@ const std::unordered_map<std::string_view, std::string_view> config::defaults =
     {
         {"lock_path", "/tmp/ddappsec.lock"},
         {"socket_path", "/tmp/ddappsec.sock"},
-        {"log_level", "info"},
+        {"log_level", "warn"},
         {"runner_idle_timeout", "1440" } // minutes
 };
 

--- a/src/helper/defer.hpp
+++ b/src/helper/defer.hpp
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
 namespace dds {
 
 template <typename T>

--- a/src/helper/defer.hpp
+++ b/src/helper/defer.hpp
@@ -3,12 +3,17 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
+#include <utility>
 
 namespace dds {
 
 template <typename T>
 struct defer {
-    defer(T &&r_): runnable(std::move(r_)) {}
+    explicit defer(T &&r_): runnable(std::move(r_)) {}
+    defer(const defer &) = delete;
+    defer& operator=(const defer&) = delete;
+    defer(defer &&) = delete;
+    defer& operator=(defer&&) = delete;
     ~defer() { runnable(); }
     T runnable;
 };

--- a/src/helper/defer.hpp
+++ b/src/helper/defer.hpp
@@ -1,0 +1,10 @@
+namespace dds {
+
+template <typename T>
+struct defer {
+    defer(T &&r_): runnable(std::move(r_)) {}
+    ~defer() { runnable(); }
+    T runnable;
+};
+
+} // namespace dds

--- a/src/helper/main.cpp
+++ b/src/helper/main.cpp
@@ -5,6 +5,7 @@
 // Copyright 2021 Datadog, Inc.
 #include "config.hpp"
 #include "runner.hpp"
+#include "subscriber/waf.hpp"
 #include <csignal>
 #include <fcntl.h>
 #include <iostream>
@@ -54,8 +55,10 @@ int main(int argc, char *argv[]) {
     auto logger = spdlog::stderr_color_mt("ddappsec");
     spdlog::set_default_logger(logger);
     logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e][%l][%t] %v");
-    spdlog::set_level(
-        spdlog::level::from_str(config.get<std::string>("log_level")));
+
+    auto level = spdlog::level::from_str(config.get<std::string>("log_level"));
+    spdlog::set_level(level);
+    dds::waf::initialise_logging(level);
 
     if (!ensure_unique(config)) {
         logger->warn("helper launched, but not unique, exiting");

--- a/src/helper/subscriber/waf.cpp
+++ b/src/helper/subscriber/waf.cpp
@@ -145,11 +145,6 @@ DDWAF_LOG_LEVEL spdlog_level_to_ddwaf(spdlog::level::level_enum level)
     return DDWAF_LOG_OFF;
 }
 
-
-} // namespace
-
-namespace dds::waf {
-
 void log_cb(DDWAF_LOG_LEVEL level, const char* function, const char* file,
     unsigned line, const char* message, uint64_t message_len)
 {
@@ -182,6 +177,10 @@ void log_cb(DDWAF_LOG_LEVEL level, const char* function, const char* file,
     logger->log(spdlog::source_loc{file, static_cast<int>(line), function},
         new_level, std::string_view(message, message_len));
 }
+
+} // namespace
+
+namespace dds::waf {
 
 void initialise_logging(spdlog::level::level_enum level)
 {

--- a/src/helper/subscriber/waf.cpp
+++ b/src/helper/subscriber/waf.cpp
@@ -148,11 +148,7 @@ DDWAF_LOG_LEVEL spdlog_level_to_ddwaf(spdlog::level::level_enum level)
 void log_cb(DDWAF_LOG_LEVEL level, const char* function, const char* file,
     unsigned line, const char* message, uint64_t message_len)
 {
-    auto logger = spdlog::default_logger();
-    if (!logger) { return; }
-
     auto new_level = spdlog::level::off;
-
     switch(level) {
     case DDWAF_LOG_TRACE:
         new_level = spdlog::level::trace;
@@ -174,7 +170,8 @@ void log_cb(DDWAF_LOG_LEVEL level, const char* function, const char* file,
         break;
     }
 
-    logger->log(spdlog::source_loc{file, static_cast<int>(line), function},
+    spdlog::default_logger()->log(
+        spdlog::source_loc{file, static_cast<int>(line), function},
         new_level, std::string_view(message, message_len));
 }
 

--- a/src/helper/subscriber/waf.cpp
+++ b/src/helper/subscriber/waf.cpp
@@ -124,28 +124,30 @@ dds::result format_waf_result(dds::result::code code, std::string_view json) {
 
     return res;
 }
-} // namespace
 
-namespace dds::waf {
-
-namespace {
-
-void log_cb (DDWAF_LOG_LEVEL level, const char* function, const char* file,
+void log_cb(DDWAF_LOG_LEVEL level, const char* function, const char* file,
     unsigned line, const char* message, uint64_t message_len)
 {
+    if (!spdlog::default_logger()) { return; }
+
     auto new_level = spdlog::level::off;
 
     switch(level) {
     case DDWAF_LOG_TRACE:
         new_level = spdlog::level::trace;
+        break;
     case DDWAF_LOG_DEBUG:
         new_level = spdlog::level::debug;
+        break;
     case DDWAF_LOG_INFO:
         new_level = spdlog::level::info;
+        break;
     case DDWAF_LOG_WARN:
         new_level = spdlog::level::warn;
+        break;
     case DDWAF_LOG_ERROR:
         new_level = spdlog::level::err;
+        break;
     case DDWAF_LOG_OFF: [[fallthrough]];
     default:
         break;
@@ -176,7 +178,10 @@ DDWAF_LOG_LEVEL spdlog_level_to_ddwaf(spdlog::level::level_enum level)
     }
     return DDWAF_LOG_OFF;
 }
-}
+
+} // namespace
+
+namespace dds::waf {
 
 instance::listener::listener(ddwaf_context ctx) : handle_(ctx) {}
 

--- a/src/helper/subscriber/waf.cpp
+++ b/src/helper/subscriber/waf.cpp
@@ -153,7 +153,7 @@ void log_cb (DDWAF_LOG_LEVEL level, const char* function, const char* file,
 
     spdlog::default_logger()->log(
         spdlog::source_loc{file, static_cast<int>(line), function},
-        spdlog::level::debug, std::string_view(message, message_len));
+        new_level, std::string_view(message, message_len));
 }
 
 DDWAF_LOG_LEVEL spdlog_level_to_ddwaf(spdlog::level::level_enum level)
@@ -254,8 +254,10 @@ dds::result instance::listener::call(dds::parameter &data, unsigned timeout) {
 
 instance::instance(parameter &rule) : handle_(ddwaf_init(rule.ptr(), nullptr))
 {
-    // Perhaps we need a better place to do this
-    static auto logger = []{
+    // Initialise the WAF logger only once, this is not important at the moment
+    // since we only  have one instance of the WAF, but this will prevent us
+    // from initialising it multiple times.
+    static bool logger = []{
         ddwaf_set_log_cb(log_cb,
             spdlog_level_to_ddwaf(spdlog::default_logger()->level()));
         return true;

--- a/src/helper/subscriber/waf.hpp
+++ b/src/helper/subscriber/waf.hpp
@@ -7,6 +7,7 @@
 #define WAF_HPP
 
 #include <ddwaf.h>
+#include <spdlog/spdlog.h>
 #include <string>
 #include <string_view>
 
@@ -16,6 +17,12 @@
 #include "../scope.hpp"
 
 namespace dds::waf {
+
+// The callback is exposed for testing
+void log_cb(DDWAF_LOG_LEVEL level, const char* function, const char* file,
+    unsigned line, const char* message, uint64_t message_len);
+
+void initialise_logging(spdlog::level::level_enum level);
 
 class instance : public dds::subscriber {
   public:

--- a/src/helper/subscriber/waf.hpp
+++ b/src/helper/subscriber/waf.hpp
@@ -18,10 +18,6 @@
 
 namespace dds::waf {
 
-// The callback is exposed for testing
-void log_cb(DDWAF_LOG_LEVEL level, const char* function, const char* file,
-    unsigned line, const char* message, uint64_t message_len);
-
 void initialise_logging(spdlog::level::level_enum level);
 
 class instance : public dds::subscriber {

--- a/tests/helper/CMakeLists.txt
+++ b/tests/helper/CMakeLists.txt
@@ -5,4 +5,5 @@ add_executable(ddappsec_helper_test ${DDAPPSEC_TEST_SOURCE})
 target_link_libraries(ddappsec_helper_test
     PRIVATE helper_objects libddwaf_objects pthread spdlog gtest gmock)
 
+target_include_directories(ddappsec_helper_test PRIVATE ${CMAKE_SOURCE_DIR}/third_party/)
 gtest_discover_tests(ddappsec_helper_test WORKING_DIRECTORY ${ddappsec_SOURCE_DIR}/tests/helper)

--- a/tests/helper/waf_test.cpp
+++ b/tests/helper/waf_test.cpp
@@ -128,7 +128,7 @@ TEST(WafTest, Logging) {
         sink->clear();
     }
 
-    // Count the extra  ifno message from the WAF "Sending log messages..."
+    // Count the extra if no message from the WAF "Sending log messages..."
     {
         dds::waf::initialise_logging(spdlog::level::info);
         DDWAF_TRACE("trace");

--- a/tests/helper/waf_test.cpp
+++ b/tests/helper/waf_test.cpp
@@ -3,14 +3,39 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
-#include <subscriber/waf.hpp>
+#include <libddwaf/src/log.hpp>
+
 #include <rapidjson/document.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/base_sink.h>
+#include <subscriber/waf.hpp>
 #include "common.hpp"
+
+#include <iostream>
 
 const std::string waf_rule =
     R"({"version":"2.1","rules":[{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"},"conditions":[{"operator":"match_regex","parameters":{"inputs":[{"address":"arg1","key_path":[]}],"regex":"^string.*"}},{"operator":"match_regex","parameters":{"inputs":[{"address":"arg2","key_path":[]}],"regex":".*"}}],"action":"record"}]})";
 
 namespace dds {
+
+template<typename Mutex>
+class log_counter_sink : public spdlog::sinks::base_sink <Mutex>
+{
+public:
+    size_t count() const noexcept { return counter; }
+    void clear() noexcept { counter = 0; }
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        counter++;
+    }
+
+    void flush_() override {}
+
+    size_t counter{0};
+};
+
+using log_counter_sink_st = log_counter_sink<spdlog::details::null_mutex>;
 
 TEST(WafTest, RunWithInvalidParam) {
     subscriber::ptr wi(waf::instance::from_string(waf_rule));
@@ -61,6 +86,80 @@ TEST(WafTest, ValidRunMonitor) {
         doc.Parse(match);
         EXPECT_FALSE(doc.HasParseError());
         EXPECT_TRUE(doc.IsObject());
+    }
+}
+
+TEST(WafTest, Logging) {
+    auto sink = std::make_shared<log_counter_sink_st>();
+    auto logger = std::make_shared<spdlog::logger>("ddappsec_test", sink);
+
+    spdlog::set_default_logger(logger);
+    spdlog::set_level(spdlog::level::trace);
+
+    {
+        dds::waf::initialise_logging(spdlog::level::off);
+        DDWAF_TRACE("trace");
+        DDWAF_DEBUG("debug");
+        DDWAF_INFO("info");
+        DDWAF_WARN("warn");
+        DDWAF_ERROR("error");
+        EXPECT_EQ(sink->count(), 0);
+    }
+
+    {
+        dds::waf::initialise_logging(spdlog::level::err);
+        DDWAF_TRACE("trace");
+        DDWAF_DEBUG("debug");
+        DDWAF_INFO("info");
+        DDWAF_WARN("warn");
+        DDWAF_ERROR("error");
+        EXPECT_EQ(sink->count(), 1);
+        sink->clear();
+    }
+
+    {
+        dds::waf::initialise_logging(spdlog::level::warn);
+        DDWAF_TRACE("trace");
+        DDWAF_DEBUG("debug");
+        DDWAF_INFO("info");
+        DDWAF_WARN("warn");
+        DDWAF_ERROR("error");
+        EXPECT_EQ(sink->count(), 2);
+        sink->clear();
+    }
+
+    // Count the extra  ifno message from the WAF "Sending log messages..."
+    {
+        dds::waf::initialise_logging(spdlog::level::info);
+        DDWAF_TRACE("trace");
+        DDWAF_DEBUG("debug");
+        DDWAF_INFO("info");
+        DDWAF_WARN("warn");
+        DDWAF_ERROR("error");
+        EXPECT_EQ(sink->count(), 4); 
+        sink->clear();
+    }
+
+    {
+        dds::waf::initialise_logging(spdlog::level::debug);
+        DDWAF_TRACE("trace");
+        DDWAF_DEBUG("debug");
+        DDWAF_INFO("info");
+        DDWAF_WARN("warn");
+        DDWAF_ERROR("error");
+        EXPECT_EQ(sink->count(), 5);
+        sink->clear();
+    }
+
+    {
+        dds::waf::initialise_logging(spdlog::level::trace);
+        DDWAF_TRACE("trace");
+        DDWAF_DEBUG("debug");
+        DDWAF_INFO("info");
+        DDWAF_WARN("warn");
+        DDWAF_ERROR("error");
+        EXPECT_EQ(sink->count(), 6);
+        sink->clear();
     }
 }
 

--- a/tests/helper/waf_test.cpp
+++ b/tests/helper/waf_test.cpp
@@ -128,7 +128,7 @@ TEST(WafTest, Logging) {
         sink->clear();
     }
 
-    // Count the extra if no message from the WAF "Sending log messages..."
+    // Count the extra info message from the WAF "Sending log messages..."
     {
         dds::waf::initialise_logging(spdlog::level::info);
         DDWAF_TRACE("trace");

--- a/tests/helper/waf_test.cpp
+++ b/tests/helper/waf_test.cpp
@@ -90,6 +90,8 @@ TEST(WafTest, ValidRunMonitor) {
 }
 
 TEST(WafTest, Logging) {
+    auto old_logger = spdlog::default_logger();
+
     auto sink = std::make_shared<log_counter_sink_st>();
     auto logger = std::make_shared<spdlog::logger>("ddappsec_test", sink);
 
@@ -161,6 +163,8 @@ TEST(WafTest, Logging) {
         EXPECT_EQ(sink->count(), 6);
         sink->clear();
     }
+
+    spdlog::set_default_logger(old_logger);
 }
 
 } // namespace dds


### PR DESCRIPTION
### Description

Updated the WAF to version 1.0.15 and added the missing logger callback.

### Describe how to test your changes

Tested manually + unit.

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass
- [x] If known, an appropriate milestone has been selected
- [x] All new source files include the required notice
