### PR TITLE
Align env/ini priorities with tracer

### DIFF
--- a/src/extension/logging.c
+++ b/src/extension/logging.c
@@ -178,39 +178,39 @@ static dd_result _do_dd_log_init() // guarded by mutex
     return dd_success;
 }
 
-static dd_log_level_t _dd_log_level_from_str(const char *nullable log_level)
+static int _dd_log_level_from_str(const char *nullable log_level)
 {
     if (log_level == NULL) {
         goto err;
     }
 
     size_t len = strlen((const char *)log_level);
-    if (STR_CONS_EQ(log_level, len, "off")) {
+    if (dd_string_equals_lc(log_level, len, ZEND_STRL("off"))) {
         return dd_log_off;
     }
-    if (STR_CONS_EQ(log_level, len, "error")) {
-        return dd_log_error;
-    }
-    if (STR_CONS_EQ(log_level, len, "fatal")) {
+    if (dd_string_equals_lc(log_level, len, ZEND_STRL("fatal"))) {
         return dd_log_fatal;
     }
-    if (STR_CONS_EQ(log_level, len, "warning") ||
-        STR_CONS_EQ(log_level, len, "warn")) {
+    if (dd_string_equals_lc(log_level, len, ZEND_STRL("error"))) {
+        return dd_log_error;
+    }
+    if (dd_string_equals_lc(log_level, len, ZEND_STRL("warning")) ||
+        dd_string_equals_lc(log_level, len, ZEND_STRL("warn"))) {
         return dd_log_warning;
     }
-    if (STR_CONS_EQ(log_level, len, "info")) {
+    if (dd_string_equals_lc(log_level, len, ZEND_STRL("info"))) {
         return dd_log_info;
     }
-    if (STR_CONS_EQ(log_level, len, "debug")) {
+    if (dd_string_equals_lc(log_level, len, ZEND_STRL("debug"))) {
         return dd_log_debug;
     }
-    if (STR_CONS_EQ(log_level, len, "trace")) {
+    if (dd_string_equals_lc(log_level, len, ZEND_STRL("trace"))) {
         return dd_log_trace;
     }
 
 err:
     /* Fallback on a reasonable log level */
-    return dd_log_error;
+    return -1;
 }
 
 static const char *nonnull _dd_log_level_to_str(dd_log_level_t log_level)
@@ -472,8 +472,12 @@ static ZEND_INI_MH(_on_update_log_level)
     }
 
     char *str_value = ZSTR_VAL(new_value);
-    dd_log_level = _dd_log_level_from_str(str_value);
+    int level = _dd_log_level_from_str(str_value);
+    if (level == -1) {
+        return FAILURE;
+    }
 
+    dd_log_level = level;
     return SUCCESS;
 }
 static ZEND_INI_MH(_on_update_log_file)

--- a/src/extension/php_objects.c
+++ b/src/extension/php_objects.c
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 #include "php_objects.h"
+#include "attributes.h"
 #include "ddappsec.h"
 #include "dddefs.h"
 #include "php_compat.h"
@@ -42,7 +43,20 @@ dd_result dd_phpobj_reg_ini(const zend_ini_entry_def *entries)
 #define ENV_NAME_PREFIX "DD_APPSEC_"
 #define ENV_NAME_PREFIX_LEN (sizeof(ENV_NAME_PREFIX) - 1)
 
+#define ZEND_INI_MH_PASSTHRU entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage
 static zend_string *nullable _fetch_from_env(const char *name, size_t name_len);
+static ZEND_INI_MH(_on_modify_wrapper);
+struct entry_ex {
+    ZEND_INI_MH((*orig_on_modify));
+    const char *hardcoded_def;
+    uint16_t hardcoded_def_len;
+    bool has_env;
+    char _padding[5]; // NOLINT ensure padding is initialized to zeros
+};
+_Static_assert(sizeof(struct entry_ex) == 24, "Size is 24"); // NOLINT
+_Static_assert(offsetof(zend_string, val) % _Alignof(struct entry_ex) == 0,
+    "val offset of zend_string is compatible with alignment of entry_ex");
+
 void dd_phpobj_reg_ini_env(const dd_ini_setting *sett)
 {
     size_t name_len = NAME_PREFIX_LEN + sett->name_suff_len;
@@ -54,6 +68,15 @@ void dd_phpobj_reg_ini_env(const dd_ini_setting *sett)
     zend_string *env_def =
         _fetch_from_env(sett->name_suff, sett->name_suff_len);
 
+    zend_string *entry_ex_fake_str = zend_string_init_interned(
+        (char *)&(struct entry_ex){
+            .orig_on_modify = sett->on_modify,
+            .hardcoded_def = sett->default_value,
+            .hardcoded_def_len = sett->default_value_len,
+            .has_env = env_def ? true : false,
+        },
+        sizeof(struct entry_ex), 1);
+
     const zend_ini_entry_def defs[] = {
         {
             .name = name,
@@ -63,9 +86,10 @@ void dd_phpobj_reg_ini_env(const dd_ini_setting *sett)
             .value_length =
                 env_def ? ZSTR_LEN(env_def) : (uint32_t)sett->default_value_len,
 
-            .on_modify = sett->on_modify,
+            .on_modify = _on_modify_wrapper,
             .mh_arg1 = (void *)(uintptr_t)sett->field_offset,
             .mh_arg2 = sett->global_variable,
+            .mh_arg3 = ZSTR_VAL(entry_ex_fake_str),
         },
         {0}};
 
@@ -104,6 +128,49 @@ static zend_string *nullable _fetch_from_env(const char *name, size_t name_len)
         return NULL;
     }
     return zend_string_init(res, strlen(res), 0);
+}
+
+static ZEND_INI_MH(_on_modify_wrapper)
+{
+    // env values have priority, except we still allow runtime overrides
+    // this may be surprising, but it's what the tracer does
+
+    struct entry_ex *eex = mh_arg3;
+
+    if (!eex->has_env /* no env value, no limitations */ ||
+        // runtime changes are still allowed
+        stage != ZEND_INI_STAGE_STARTUP) {
+        return eex->orig_on_modify(ZEND_INI_MH_PASSTHRU);
+    }
+    // else we have env value and we're at startup stage
+
+    if (entry->value) {
+        // if we have a value, we're either in the beginning of a new thread
+        // or the value came from the the ini_def default (the env value)
+        // in both cases we allow
+        // see zend_register_ini_entries
+        int res = eex->orig_on_modify(ZEND_INI_MH_PASSTHRU);
+        if (UNEXPECTED(res == FAILURE)) {
+            // if this fails though, we're in a bit of a problem. It means
+            // that the env value is no good. We retry with the hardcoded
+            // default, which should always work
+            if (EXPECTED(entry->value)) {
+                zend_string_release(entry->value);
+            }
+            entry->value = zend_string_init_interned(
+                eex->hardcoded_def, eex->hardcoded_def_len, 1);
+            new_value = entry->value; // modify argument variable
+            res = eex->orig_on_modify(ZEND_INI_MH_PASSTHRU);
+            UNUSED(res);
+            assert(res == SUCCESS);
+            return FAILURE;
+        }
+    }
+
+    // else our env value was overriden by ini settings. we don't allow that
+    // so we return FAILURE so that we run next with the ini_entry_def default,
+    // i.e, the env value
+    return FAILURE;
 }
 
 void dd_phpobj_reg_long_const(

--- a/tests/extension/bad_env_ini.phpt
+++ b/tests/extension/bad_env_ini.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bad env var setting results in hardcoded default fallback
+--ENV--
+DD_APPSEC_LOG_LEVEL=bad
+--GET--
+_force_cgi_sapi
+--INI--
+; ignored because overridden by environment
+datadog.appsec.log_level=trace
+--FILE--
+<?php
+// should be the hardcoded defaultl
+var_dump(ini_get("datadog.appsec.log_level"));
+?>
+--EXPECTF--
+string(4) "warn"

--- a/tests/extension/enabled_ini_disabled_env.phpt
+++ b/tests/extension/enabled_ini_disabled_env.phpt
@@ -11,4 +11,4 @@ datadog.appsec.enabled=true
 var_dump(ini_get("datadog.appsec.enabled"));
 ?>
 --EXPECTF--
-string(1) "1"
+string(5) "false"


### PR DESCRIPTION
### Description

Make env variables have priority over explicit non-request-time ini values.

### Motivation

To align with tracer behavior.

### Readiness checklist

- [x] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected

### Release checklist

- [ ] The CHANGELOG.md has been updated


