### PR TITLE
Fuzzer use-after-free 

### DIFF
--- a/src/helper/client_settings.cpp
+++ b/src/helper/client_settings.cpp
@@ -25,21 +25,29 @@ namespace dds {
 
 namespace {
 struct def_rules_file {
-    def_rules_file()
+    def_rules_file() noexcept
     {
-        std::error_code ec;
-        auto self = std::filesystem::read_symlink({"/proc/self/exe"}, ec);
-        if (ec) {
-            // should not happen on Linux
-            file = "<error resolving /proc/self/exe: " + ec.message() + ">";
-        } else {
-            auto self_dir = self.parent_path();
-            file = self_dir / "../etc/dd-appsec/recommended.json";
+        try {
+            std::error_code ec;
+            auto self = std::filesystem::read_symlink({"/proc/self/exe"}, ec);
+            if (ec) {
+                // should not happen on Linux
+                file = "<error resolving /proc/self/exe: " + ec.message() + ">";
+            } else {
+                auto self_dir = self.parent_path();
+                file = self_dir / "../etc/dd-appsec/recommended.json";
+            }
+        } catch (const std::exception &e) {
+            file = "<exception resolving /proc/self/exe: " +
+                std::string(e.what()) + ">";
+        } catch (...) {
+            file = "<unknown exception resolving /proc/self/exe>";
         }
     }
     std::string file;
 };
 
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 def_rules_file drf;
 
 } // namespace

--- a/src/helper/client_settings.cpp
+++ b/src/helper/client_settings.cpp
@@ -23,25 +23,29 @@ namespace filesystem = experimental::filesystem;
 #endif
 namespace dds {
 
+namespace {
+struct def_rules_file {
+    def_rules_file()
+    {
+        std::error_code ec;
+        auto self = std::filesystem::read_symlink({"/proc/self/exe"}, ec);
+        if (ec) {
+            // should not happen on Linux
+            file = "<error resolving /proc/self/exe: " + ec.message() + ">";
+        } else {
+            auto self_dir = self.parent_path();
+            file = self_dir / "../etc/dd-appsec/recommended.json";
+        }
+    }
+    std::string file;
+};
+
+def_rules_file drf;
+
+} // namespace
+
 const std::string &client_settings::default_rules_file()
 {
-    struct def_rules_file {
-        def_rules_file()
-        {
-            std::error_code ec;
-            auto self = std::filesystem::read_symlink({"/proc/self/exe"}, ec);
-            if (ec) {
-                // should not happen on Linux
-                file = "<error resolving /proc/self/exe: " + ec.message() + ">";
-            } else {
-                auto self_dir = self.parent_path();
-                file = self_dir / "../etc/dd-appsec/recommended.json";
-            }
-        }
-        std::string file;
-    };
-
-    static def_rules_file drf;
     return drf.file;
 }
 } // namespace dds


### PR DESCRIPTION
### Description

Use-after-free in the fuzzer caused by atexit and function-scoped statics.

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


