### PR TITLE
Override libfuzzer main

### DIFF
--- a/.github/workflows/helper.yml
+++ b/.github/workflows/helper.yml
@@ -158,9 +158,9 @@ jobs:
             LLVM_PROFILE_FILE: body.profraw
       - name: Generate coverage
         run: |
-            llvm-profdata-10 merge -sparse *.profraw -o default.profdata
-            llvm-cov-10 show build/tests/fuzzer/ddappsec_helper_fuzzer -instr-profile=default.profdata -ignore-filename-regex="(tests|third_party|build)" -format=html > coverage.html
-            llvm-cov-10 report -instr-profile default.profdata build/tests/fuzzer/ddappsec_helper_fuzzer -ignore-filename-regex="(tests|third_party|build)" -show-region-summary=false
+            llvm-profdata-13 merge -sparse *.profraw -o default.profdata
+            llvm-cov-13 show build/tests/fuzzer/ddappsec_helper_fuzzer -instr-profile=default.profdata -ignore-filename-regex="(tests|third_party|build)" -format=html > coverage.html
+            llvm-cov-13 report -instr-profile default.profdata build/tests/fuzzer/ddappsec_helper_fuzzer -ignore-filename-regex="(tests|third_party|build)" -show-region-summary=false
         working-directory: ${{ github.workspace }}
       - uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/helper.yml
+++ b/.github/workflows/helper.yml
@@ -110,15 +110,16 @@ jobs:
             ~/.hunter
           key: ${{ runner.os }}-helper
       - name: Install clang
-        run: sudo apt-get install clang
+        run: |
+          sudo .github/workflows/scripts/llvm.sh 13
       - name: Generate Build Scripts
         run: |
             mkdir build
             cd build
             cmake .. -DCMAKE_BUILD_TYPE=Debug  -DDD_APPSEC_BUILD_EXTENSION=OFF
         env:
-            CXX: clang++
-            CC: clang
+            CXX: clang++-13
+            CC: clang-13
       - name: Build
         run: make -j $(nproc) ddappsec_helper_fuzzer corpus_generator
         working-directory: ${{ github.workspace }}/build

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -5,7 +5,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSIO
     target_include_directories(ddappsec_helper_fuzzer PRIVATE ${HELPER_INCLUDE_DIR})
 
     execute_process(
-        COMMAND bash -c "${CMAKE_CXX_COMPILER} -print-runtime-dir"
+        COMMAND ${CMAKE_CXX_COMPILER} -print-runtime-dir
         OUTPUT_VARIABLE LLVM_RUNTIME_DIR
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -1,9 +1,20 @@
-add_executable(ddappsec_helper_fuzzer ${HELPER_SOURCE} main.cpp mutators.cpp)
-set_target_properties(ddappsec_helper_fuzzer PROPERTIES COMPILE_FLAGS "-fsanitize=fuzzer,address,leak -fprofile-instr-generate -fcoverage-mapping")
-set_target_properties(ddappsec_helper_fuzzer PROPERTIES LINK_FLAGS "-fsanitize=fuzzer,address,leak -fprofile-instr-generate -fcoverage-mapping")
-target_include_directories(ddappsec_helper_fuzzer PRIVATE ${HELPER_INCLUDE_DIR})
-target_link_libraries(ddappsec_helper_fuzzer
-    PRIVATE libddwaf_objects pthread spdlog msgpack_c lib_rapidjson Boost::system)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0)
+    add_executable(ddappsec_helper_fuzzer ${HELPER_SOURCE} main.cpp mutators.cpp)
+    set_target_properties(ddappsec_helper_fuzzer PROPERTIES COMPILE_FLAGS "-fsanitize=fuzzer-no-link,address,leak -fprofile-instr-generate -fcoverage-mapping")
+    set_target_properties(ddappsec_helper_fuzzer PROPERTIES LINK_FLAGS "-fsanitize=fuzzer-no-link,address,leak -fprofile-instr-generate -fcoverage-mapping")
+    target_include_directories(ddappsec_helper_fuzzer PRIVATE ${HELPER_INCLUDE_DIR})
 
-add_executable(corpus_generator corpus_generator.cpp)
-target_link_libraries(corpus_generator PRIVATE helper_objects libddwaf_objects pthread spdlog)
+    # Extract major version
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" VERSION_MATCH ${CMAKE_CXX_COMPILER_VERSION})
+    set(CXX_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+    set(CXX_MAJOR ${CMAKE_MATCH_1})
+
+    message("/usr/lib/llvm-${CXX_MAJOR}/lib/clang/${CXX_VERSION}/lib/linux/")
+    target_link_directories(ddappsec_helper_fuzzer PRIVATE 
+        "/usr/lib/llvm-${CXX_MAJOR}/lib/clang/${CXX_VERSION}/lib/linux/")
+    target_link_libraries(ddappsec_helper_fuzzer
+        PRIVATE libddwaf_objects pthread spdlog msgpack_c lib_rapidjson Boost::system libclang_rt.fuzzer_no_main-x86_64.a)
+
+    add_executable(corpus_generator corpus_generator.cpp)
+    target_link_libraries(corpus_generator PRIVATE helper_objects libddwaf_objects pthread spdlog)
+endif()

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -1,17 +1,16 @@
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0.0)
     add_executable(ddappsec_helper_fuzzer ${HELPER_SOURCE} main.cpp mutators.cpp)
     set_target_properties(ddappsec_helper_fuzzer PROPERTIES COMPILE_FLAGS "-fsanitize=fuzzer-no-link,address,leak -fprofile-instr-generate -fcoverage-mapping")
     set_target_properties(ddappsec_helper_fuzzer PROPERTIES LINK_FLAGS "-fsanitize=fuzzer-no-link,address,leak -fprofile-instr-generate -fcoverage-mapping")
     target_include_directories(ddappsec_helper_fuzzer PRIVATE ${HELPER_INCLUDE_DIR})
 
-    # Extract major version
-    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" VERSION_MATCH ${CMAKE_CXX_COMPILER_VERSION})
-    set(CXX_VERSION ${CMAKE_CXX_COMPILER_VERSION})
-    set(CXX_MAJOR ${CMAKE_MATCH_1})
+    execute_process(
+        COMMAND bash -c "${CMAKE_CXX_COMPILER} -print-runtime-dir"
+        OUTPUT_VARIABLE LLVM_RUNTIME_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-    message("/usr/lib/llvm-${CXX_MAJOR}/lib/clang/${CXX_VERSION}/lib/linux/")
-    target_link_directories(ddappsec_helper_fuzzer PRIVATE 
-        "/usr/lib/llvm-${CXX_MAJOR}/lib/clang/${CXX_VERSION}/lib/linux/")
+    target_link_directories(ddappsec_helper_fuzzer PRIVATE ${LLVM_RUNTIME_DIR})
     target_link_libraries(ddappsec_helper_fuzzer
         PRIVATE libddwaf_objects pthread spdlog msgpack_c lib_rapidjson Boost::system libclang_rt.fuzzer_no_main-x86_64.a)
 

--- a/tests/fuzzer/main.cpp
+++ b/tests/fuzzer/main.cpp
@@ -11,29 +11,35 @@
 #include "network.hpp"
 #include <iostream>
 
-std::thread runner_thread;
-std::unique_ptr<dds::runner> runner;
 dds::fuzzer::acceptor *acceptor;
-dds::config::config config;
 std::function<decltype(RawMutator)> mutator;
-auto logger = spdlog::stderr_color_mt("ddappsec");
 
-void exit_handler()
-{
-    runner->exit();
-    acceptor->exit();
-
-    runner_thread.join();
-
-    runner.reset(nullptr);
-}
+extern "C" int LLVMFuzzerRunDriver(int *argc, char ***argv,
+                  int (*UserCb)(const uint8_t *Data, size_t Size));
 
 extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
-    std::atexit(exit_handler);
+    return 0;
+}
 
-    config = dds::config::config(*argc, *argv);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* bytes, size_t size)
+{
+    acceptor->push_socket(std::make_unique<dds::fuzzer::raw_socket>(bytes, size));
+    return 0;
+}
 
+// The custom mutator:
+extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *Data, size_t Size,
+                                          size_t MaxSize, unsigned int Seed)
+{
+    return mutator(Data, Size, MaxSize, Seed);
+}
+
+int main(int argc, char **argv)
+{
+    dds::config::config config(argc, argv);
+
+    auto logger = spdlog::stderr_color_mt("ddappsec");
     spdlog::set_default_logger(logger);
     logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e][%l][%t] %v");
     spdlog::set_level(
@@ -60,27 +66,14 @@ extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
 
     auto acceptor_ptr = std::make_unique<dds::fuzzer::acceptor>();
     acceptor = acceptor_ptr.get();
-    runner = std::make_unique<dds::runner>(config, std::move(acceptor_ptr));
+    dds::runner runner(config, std::move(acceptor_ptr));
 
-    runner_thread = std::move(std::thread([]() {
-        runner->run(); 
-    }));
+    auto runner_thread([&runner]{ runner.run(); });
 
-    return 0;
-}
+    int result =  LLVMFuzzerRunDriver(&argc, &argv, LLVMFuzzerTestOneInput);
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* bytes, size_t size)
-{
-    acceptor->push_socket(std::make_unique<dds::fuzzer::raw_socket>(bytes, size));
+    runner.exit();
+    acceptor->exit();
 
-    // TODO: configurable rate-limit and sequential mode
-
-    return 0;
-}
-
-// The custom mutator:
-extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *Data, size_t Size,
-                                          size_t MaxSize, unsigned int Seed)
-{
-    return mutator(Data, Size, MaxSize, Seed);
+    return result;
 }

--- a/tests/fuzzer/main.cpp
+++ b/tests/fuzzer/main.cpp
@@ -68,12 +68,14 @@ int main(int argc, char **argv)
     acceptor = acceptor_ptr.get();
     dds::runner runner(config, std::move(acceptor_ptr));
 
-    auto runner_thread([&runner]{ runner.run(); });
+    std::thread runner_thread([&runner]{ runner.run(); });
 
     int result =  LLVMFuzzerRunDriver(&argc, &argv, LLVMFuzzerTestOneInput);
 
     runner.exit();
     acceptor->exit();
+
+    runner_thread.join();
 
     return result;
 }


### PR DESCRIPTION
### Description

Currently the fuzzer uses an `atexit` handler to finalize the runner and acceptor. Unfortunately this means that static objects initialised after the handler has been registered will be freed before the runner, causing use-after-free issues.

To solve this problem, we're now using libfuzzer as a library and providing our own main, which helps to control the lifetime of the runner.

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


