### PR TITLE
Fix bug parsing Forwarded headers

### DIFF
--- a/src/extension/ip_extraction.c
+++ b/src/extension/ip_extraction.c
@@ -334,8 +334,8 @@ static bool _parse_forwarded(zend_string *nonnull zvalue, ipaddr *nonnull out)
                     if (succ && !_is_private(out)) {
                         return true;
                     }
-                    state = between;
                 }
+                state = between;
             } else if (*r == '\\') {
                 r++;
             }

--- a/tests/extension/extract_ip_addr.phpt
+++ b/tests/extension/extract_ip_addr.phpt
@@ -36,6 +36,7 @@ test('x_forwarded', 'for=127.0.0.1, FOR=1.1.1.1');
 test('x_forwarded', 'for="\"foobar";proto=http,FOR="1.1.1.1"');
 test('x_forwarded', 'for="8.8.8.8:2222",');
 test('x_forwarded', 'for="8.8.8.8'); // quote not closed
+test('x_forwarded', 'far="8.8.8.8",for=4.4.4.4;');
 //\datadog\appsec\testing\stop_for_debugger();
 test('x_forwarded', '   for=127.0.0.1,for= for=,for=;"for = for="" ,; for=8.8.8.8;');
 
@@ -129,6 +130,9 @@ string(7) "8.8.8.8"
 
 x_forwarded: for="8.8.8.8
 NULL
+
+x_forwarded: far="8.8.8.8",for=4.4.4.4;
+string(7) "4.4.4.4"
 
 x_forwarded:    for=127.0.0.1,for= for=,for=;"for = for="" ,; for=8.8.8.8;
 string(7) "8.8.8.8"


### PR DESCRIPTION
### Description

Fixes a small bug in parsing forwarded headers, where the state wouldn't transition out of quoted values in case the value was not being considered for IP address parsing.

### Readiness checklist

- [x] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


