### PR TITLE
Add system tests in CI

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -74,4 +74,5 @@ jobs:
             8.1.0 8.0.11 7.4.24 7.3.31 7.2.34 7.1.33 7.0.33
       - uses: actions/upload-artifact@v2
         with:
+          name: package
           path: /tmp/out/*.tar.gz

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,0 +1,53 @@
+name: system-tests
+
+on:
+  workflow_run:
+    workflows: ["Package"]
+    types:
+      - completed
+  push:
+    branches: [ cbeauchesne/system-tests ]
+  workflow_dispatch:
+
+jobs:
+  system-tests:
+    runs-on: ubuntu-latest
+    env:
+      TEST_LIBRARY: php
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+    steps:
+      - name: Checkout system tests
+        uses: actions/checkout@v2
+        with:
+          repository: 'DataDog/system-tests'
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: package.yml
+          workflow_conclusion: success
+          name: package
+          path: binaries/
+
+      - name: Remove debug package
+        run: |
+          ls -la binaries/
+          rm binaries/*debug.tar.gz
+
+      - name: Build
+        run: ./build.sh
+
+      - name: Run
+        run: ./run.sh
+
+      - name: Compress artifact
+        if: ${{ always() }}
+        run: tar -czvf artifact.tar.gz $(ls | grep logs)
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: logs
+          path: artifact.tar.gz
+

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -5,8 +5,6 @@ on:
     workflows: ["Package"]
     types:
       - completed
-  push:
-    branches: [ cbeauchesne/system-tests ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Package"]
     types:
       - completed
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Description

Add system tests in CI

### Motivation

Provide a functional test suite

The test follow the `package` step, as system tests needs a build artifact.

Sucesful run : https://github.com/DataDog/dd-appsec-php/runs/5005108100?check_suite_focus=true#step:6:1
