### PR TITLE
Add a nightly run for system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -7,6 +7,8 @@ on:
       - completed
     branches: [ master ]
   workflow_dispatch:
+  schedule:
+    - cron:  '00 04 * * 2-6'
 
 jobs:
   system-tests:


### PR DESCRIPTION
### Description

Add a nightly job  for system test

### Motivation

Check continuously the compabiliy of master branch of `dd-appsec-php` with other components. If one component releases something incompatible with it, and there is no activity on the repo, this job will tackle the issue as soon as the other component is released.
