### PR TITLE
Update installer links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Datadog Application Security (AppSec) extension for PHP.
 
 ## Installation
 
-To install the Datadog AppSec extension, first download the [installer](https://raw.githubusercontent.com/DataDog/dd-trace-php/cataphract/appsec-installer/dd-library-php-setup.php) from the Datadog Tracer repository. 
+To install the Datadog AppSec extension, first download the [installer](https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php) from the Datadog AppSec repository. 
 
 ```
-$ wget https://raw.githubusercontent.com/DataDog/dd-trace-php/cataphract/appsec-installer/dd-library-php-setup.php
+$ wget https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php
 ```
 :exclamation: This extension requires version `0.67.0` or above of the [Datadog PHP Tracer (ddtrace)](https://github.com/DataDog/dd-trace-php) and version `7.0` or above of [PHP](https://php.net). 
 
@@ -26,7 +26,7 @@ This installation requires an active internet connection and the installer menti
 
 To install both the Tracer and AppSec extensions, use the following command:
 ```
-$ php dd-library-php-setup.php --tracer-version=latest --appsec-version=latest
+$ php dd-library-php-setup.php --php-bin all --tracer-version=latest --appsec-version=latest
 ```
 
 ### Offline Installation

--- a/tests/docker/alpine-apache2-fpm/Dockerfile
+++ b/tests/docker/alpine-apache2-fpm/Dockerfile
@@ -7,7 +7,7 @@ FROM php:$PHP_VERSION-fpm-alpine
 RUN apk add --no-cache apache2 apache2-proxy libexecinfo bash
 
 ARG TRACER_VERSION
-RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-trace-php/cataphract/appsec-installer/dd-library-php-setup.php && \
+RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
 	PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
 
 RUN rm -rf /var/www/localhost/htdocs

--- a/tests/docker/apache2-fpm/Dockerfile
+++ b/tests/docker/apache2-fpm/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 ARG TRACER_VERSION
-RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-trace-php/cataphract/appsec-installer/dd-library-php-setup.php && \
+RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
 	PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
 
 RUN rm -rf /var/www/html


### PR DESCRIPTION
### Description

The installer links on the README and some of the docker containers were outdated, so this PR just updates them to the current installer.

Reported in https://github.com/DataDog/dd-appsec-php/issues/75
### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


