### PR TITLE
Update version number to 0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ HunterGate(
     URL "https://github.com/cpp-pm/hunter/archive/v0.23.314.tar.gz"
     SHA1 "95c47c92f68edb091b5d6d18924baabe02a6962a")
 
-project(ddappsec VERSION 0.2.2)
+project(ddappsec VERSION 0.3.0)
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
### Description

To be able to activate test only for the dev version, we need to have a version number different from last release
