### PR TITLE
Parameter View

### DIFF
--- a/src/helper/client.cpp
+++ b/src/helper/client.cpp
@@ -10,7 +10,6 @@
 #include "network/proto.hpp"
 #include "std_logging.hpp"
 #include <chrono>
-#include <iostream>
 #include <mutex>
 #include <spdlog/spdlog.h>
 #include <string>

--- a/src/helper/client.hpp
+++ b/src/helper/client.hpp
@@ -3,8 +3,7 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef CLIENT_HPP
-#define CLIENT_HPP
+#pragma once
 
 #include <cstdint>
 
@@ -60,5 +59,3 @@ protected:
 };
 
 } // namespace dds
-
-#endif // CLIENT_HPP

--- a/src/helper/config.hpp
+++ b/src/helper/config.hpp
@@ -3,8 +3,7 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef CONFIG_HPP
-#define CONFIG_HPP
+#pragma once
 
 #include <boost/lexical_cast.hpp>
 #include <unordered_map>
@@ -36,4 +35,3 @@ template <>
 std::string_view config::get<std::string_view>(std::string_view key) const;
 
 } // namespace dds::config
-#endif

--- a/src/helper/engine.cpp
+++ b/src/helper/engine.cpp
@@ -40,7 +40,7 @@ result engine::context::publish(parameter &&param)
     }
 
     std::set<subscriber::ptr> sub_set;
-    for (auto &entry : data) {
+    for (const auto &entry : data) {
         auto key = entry.key();
         DD_STDLOG(DD_STDLOG_IG_DATA_PUSHED, key);
         auto it = subscriptions_.find(key);

--- a/src/helper/engine.cpp
+++ b/src/helper/engine.cpp
@@ -29,12 +29,11 @@ void engine::subscribe(const subscriber::ptr &sub)
 
 result engine::context::publish(parameter &&param)
 {
-    parameter_view data(param);
-
     // Once the parameter reaches this function, it is guaranteed to be
     // owned by the engine.
     prev_published_params_.push_back(std::move(param));
 
+    parameter_view data(prev_published_params_.back());
     if (!data.is_map()) {
         throw invalid_object(".", "not a map");
     }

--- a/src/helper/engine.cpp
+++ b/src/helper/engine.cpp
@@ -9,6 +9,7 @@
 
 #include "engine.hpp"
 #include "exception.hpp"
+#include "parameter_view.hpp"
 #include "std_logging.hpp"
 
 namespace dds {
@@ -26,25 +27,21 @@ void engine::subscribe(const subscriber::ptr &sub)
     }
 }
 
-engine::context::~context()
-{
-    for (auto &param : prev_published_params_) { param.free(); }
-}
-
 result engine::context::publish(parameter &&param)
 {
+    parameter_view data(param);
+
     // Once the parameter reaches this function, it is guaranteed to be
     // owned by the engine.
     prev_published_params_.push_back(std::move(param));
 
-    auto &data = prev_published_params_.back();
     if (!data.is_map()) {
         throw invalid_object(".", "not a map");
     }
 
     std::set<subscriber::ptr> sub_set;
-    for (size_t i = 0; i < data.size(); i++) {
-        auto key = data[i].key();
+    for (auto &entry : data) {
+        auto key = entry.key();
         DD_STDLOG(DD_STDLOG_IG_DATA_PUSHED, key);
         auto it = subscriptions_.find(key);
         if (it == subscriptions_.end()) {

--- a/src/helper/engine.hpp
+++ b/src/helper/engine.hpp
@@ -48,7 +48,7 @@ public:
         context &operator=(const context &) = delete;
         context(context &&) = delete;
         context &operator=(context &&) = delete;
-        ~context();
+        ~context() = default;
 
         result publish(parameter &&param);
 

--- a/src/helper/engine.hpp
+++ b/src/helper/engine.hpp
@@ -3,15 +3,14 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef ENGINE_HPP
-#define ENGINE_HPP
+#pragma once
+
 #include "client_settings.hpp"
 #include "config.hpp"
 #include "parameter.hpp"
 #include "rate_limit.hpp"
 #include "result.hpp"
 #include "subscriber/base.hpp"
-#include <iostream>
 #include <map>
 #include <memory>
 #include <spdlog/fmt/ostr.h>
@@ -76,5 +75,3 @@ protected:
 };
 
 } // namespace dds
-
-#endif // ENGINE_HPP

--- a/src/helper/exception.hpp
+++ b/src/helper/exception.hpp
@@ -3,8 +3,7 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef WAF_EXCEPTION_HPP
-#define WAF_EXCEPTION_HPP
+#pragma once
 
 #include <stdexcept>
 #include <string>
@@ -101,4 +100,3 @@ public:
 };
 
 } // namespace dds
-#endif

--- a/src/helper/exception.hpp
+++ b/src/helper/exception.hpp
@@ -68,6 +68,18 @@ protected:
     const std::string what_;
 };
 
+class invalid_type : public std::exception {
+public:
+    explicit invalid_type(std::string what) : what_(std::move(what)) {}
+    [[nodiscard]] const char *what() const noexcept override
+    {
+        return what_.c_str();
+    }
+
+protected:
+    const std::string what_;
+};
+
 class bad_cast : public std::exception {
 public:
     explicit bad_cast(std::string what) : what_(std::move(what)) {}

--- a/src/helper/json_helper.cpp
+++ b/src/helper/json_helper.cpp
@@ -20,7 +20,7 @@ namespace {
 
 // TODO: Fix infinite recursion
 template <typename T>
-// NOLINTNEXTLINE(misc-no-recursion)
+// NOLINTNEXTLINE(misc-no-recursion, google-runtime-references)
 void parameter_to_json_helper(const parameter_view &pv, T &output,
     rapidjson::Document::AllocatorType &alloc)
 {

--- a/src/helper/json_helper.cpp
+++ b/src/helper/json_helper.cpp
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+
+#include <string_view>
+
+#include "json_helper.hpp"
+#include "parameter.hpp"
+#include "parameter_view.hpp"
+#include "std_logging.hpp"
+
+namespace dds {
+
+namespace {
+
+template <typename T>
+void parameter_to_json_helper(const parameter_view &pv,
+        T &output, rapidjson::Document::AllocatorType &alloc)
+{
+    switch (pv.type()) {
+    case parameter_type::int64:
+        output.SetInt64(int64_t(pv));
+        break;
+    case parameter_type::uint64:
+        output.SetUint64(uint64_t(pv));
+        break;
+    case parameter_type::string:
+        {
+            std::string_view sv = std::string_view(pv);
+            output.SetString(sv.data(), sv.size(), alloc);
+        }
+        break;
+    case parameter_type::map:
+        output.SetObject();
+        for (auto &v : pv) {
+            rapidjson::Value key, value;
+            parameter_to_json_helper(v, value, alloc);
+
+            std::string_view sv = v.key();
+            key.SetString(sv.data(), sv.size(), alloc);
+
+            output.AddMember(key, value, alloc);
+        }
+        break;
+    case parameter_type::array:
+        output.SetArray();
+        for (auto &v : pv) {
+            rapidjson::Value value;
+            parameter_to_json_helper(v, value, alloc);
+            output.PushBack(value, alloc);
+        }
+        break;
+    case parameter_type::invalid:
+        throw std::runtime_error("invalid parameter in structure");
+    };
+}
+
+}
+
+std::string parameter_to_json(const parameter_view &pv)
+{
+    try {
+        rapidjson::Document document;
+        rapidjson::Document::AllocatorType &alloc = document.GetAllocator();
+
+        parameter_to_json_helper(pv, document, alloc);
+
+        dds::string_buffer buffer;
+        rapidjson::Writer<decltype(buffer)> writer(buffer);
+
+        if (document.Accept(writer)) {
+            return std::move(buffer.get_string_ref());
+        }
+    } catch (const std::exception &e) {
+        SPDLOG_WARN("Failed to convert WAF parameter to JSON: {}", e.what());
+    }
+
+    return std::string();
+}
+
+}

--- a/src/helper/json_helper.hpp
+++ b/src/helper/json_helper.hpp
@@ -5,8 +5,8 @@
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 #pragma once
 
-#include <string>
 #include "parameter_view.hpp"
+#include <string>
 
 namespace dds {
 

--- a/src/helper/json_helper.hpp
+++ b/src/helper/json_helper.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <string>
+#include "parameter_view.hpp"
 
 namespace dds {
 
@@ -41,4 +42,5 @@ protected:
     std::string buffer_;
 };
 
+std::string parameter_to_json(const dds::parameter_view &pv);
 } // namespace dds

--- a/src/helper/main.cpp
+++ b/src/helper/main.cpp
@@ -8,7 +8,6 @@
 #include "subscriber/waf.hpp"
 #include <csignal>
 #include <fcntl.h>
-#include <iostream>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 #include <sys/file.h>

--- a/src/helper/network/acceptor.cpp
+++ b/src/helper/network/acceptor.cpp
@@ -7,7 +7,6 @@
 #include "../exception.hpp"
 #include <cerrno>
 #include <chrono>
-#include <iostream>
 #include <spdlog/spdlog.h>
 #include <stdexcept>
 #include <sys/socket.h>

--- a/src/helper/network/broker.cpp
+++ b/src/helper/network/broker.cpp
@@ -7,7 +7,6 @@
 #include "../exception.hpp"
 #include "proto.hpp"
 #include <chrono>
-#include <iostream>
 #include <msgpack.hpp>
 #include <spdlog/spdlog.h>
 #include <sstream>

--- a/src/helper/network/msgpack_helpers.cpp
+++ b/src/helper/network/msgpack_helpers.cpp
@@ -22,37 +22,27 @@ dds::parameter msgpack_to_param(const msgpack::object &o, unsigned depth = 0)
     switch (o.type) {
     case msgpack::type::ARRAY: {
         dds::parameter p = dds::parameter::array();
-        try {
-            const msgpack::object_array &array = o.via.array;
-            for (uint32_t i = 0; i < array.size; i++) {
-                const msgpack::object &item = array.ptr[i];
-                // Assume keys are strings
-                p.add(msgpack_to_param(item, depth));
-            }
-        } catch (...) {
-            p.free();
-            throw;
+        const msgpack::object_array &array = o.via.array;
+        for (uint32_t i = 0; i < array.size; i++) {
+            const msgpack::object &item = array.ptr[i];
+            // Assume keys are strings
+            p.add(msgpack_to_param(item, depth));
         }
         return p;
     }
     case msgpack::type::MAP: {
         dds::parameter p = dds::parameter::map();
-        try {
-            const msgpack::object_map &map = o.via.map;
-            for (uint32_t i = 0; i < map.size; i++) {
-                const msgpack::object_kv &kv = map.ptr[i];
-                // Assume keys are strings
-                p.add(kv.key.as<std::string_view>(),
-                    msgpack_to_param(kv.val, depth));
-            }
-        } catch (...) {
-            p.free();
-            throw;
+        const msgpack::object_map &map = o.via.map;
+        for (uint32_t i = 0; i < map.size; i++) {
+            const msgpack::object_kv &kv = map.ptr[i];
+            // Assume keys are strings
+            p.add(kv.key.as<std::string_view>(),
+                msgpack_to_param(kv.val, depth));
         }
         return p;
     }
     case msgpack::type::STR:
-        return dds::parameter{o.as<std::string_view>()};
+        return dds::parameter::string(o.as<std::string_view>());
     default:
         break;
     }

--- a/src/helper/network/msgpack_helpers.cpp
+++ b/src/helper/network/msgpack_helpers.cpp
@@ -36,8 +36,8 @@ dds::parameter msgpack_to_param(const msgpack::object &o, unsigned depth = 0)
         for (uint32_t i = 0; i < map.size; i++) {
             const msgpack::object_kv &kv = map.ptr[i];
             // Assume keys are strings
-            p.add(kv.key.as<std::string_view>(),
-                msgpack_to_param(kv.val, depth));
+            p.add(
+                kv.key.as<std::string_view>(), msgpack_to_param(kv.val, depth));
         }
         return p;
     }

--- a/src/helper/network/msgpack_helpers.cpp
+++ b/src/helper/network/msgpack_helpers.cpp
@@ -25,7 +25,6 @@ dds::parameter msgpack_to_param(const msgpack::object &o, unsigned depth = 0)
         const msgpack::object_array &array = o.via.array;
         for (uint32_t i = 0; i < array.size; i++) {
             const msgpack::object &item = array.ptr[i];
-            // Assume keys are strings
             p.add(msgpack_to_param(item, depth));
         }
         return p;

--- a/src/helper/network/msgpack_helpers.hpp
+++ b/src/helper/network/msgpack_helpers.hpp
@@ -3,8 +3,7 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef MSGPACK_HELPERS_HPP
-#define MSGPACK_HELPERS_HPP
+#pragma once
 
 #include "../parameter.hpp"
 // NOLINTNEXTLINE: msgpack.hpp is buggy and needs an include of sstream before
@@ -28,4 +27,3 @@ template <> struct convert<dds::parameter> {
 } // namespace adaptor
 } // MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
 } // namespace msgpack
-#endif

--- a/src/helper/network/proto.hpp
+++ b/src/helper/network/proto.hpp
@@ -117,7 +117,7 @@ struct request_init {
         request &operator=(const request &) = delete;
         request(request &&) = default;
         request &operator=(request &&) = default;
-        ~request() override = default;//{ data.free(); }
+        ~request() override = default; //{ data.free(); }
 
         MSGPACK_DEFINE(data)
     };

--- a/src/helper/network/proto.hpp
+++ b/src/helper/network/proto.hpp
@@ -7,7 +7,6 @@
 
 #include "client_settings.hpp"
 #include "msgpack_helpers.hpp"
-#include <iostream>
 #include <msgpack.hpp>
 #include <optional>
 #include <type_traits>
@@ -117,7 +116,7 @@ struct request_init {
         request &operator=(const request &) = delete;
         request(request &&) = default;
         request &operator=(request &&) = default;
-        ~request() override = default; //{ data.free(); }
+        ~request() override = default;
 
         MSGPACK_DEFINE(data)
     };
@@ -144,7 +143,7 @@ struct request_shutdown {
         request &operator=(const request &) = delete;
         request(request &&) = default;
         request &operator=(request &&) = default;
-        ~request() override = default; //{ data.free(); }
+        ~request() override = default;
 
         MSGPACK_DEFINE(data)
     };

--- a/src/helper/network/proto.hpp
+++ b/src/helper/network/proto.hpp
@@ -117,7 +117,7 @@ struct request_init {
         request &operator=(const request &) = delete;
         request(request &&) = default;
         request &operator=(request &&) = default;
-        ~request() override { data.free(); }
+        ~request() override = default;//{ data.free(); }
 
         MSGPACK_DEFINE(data)
     };
@@ -144,7 +144,7 @@ struct request_shutdown {
         request &operator=(const request &) = delete;
         request(request &&) = default;
         request &operator=(request &&) = default;
-        ~request() override { data.free(); }
+        ~request() override = default; //{ data.free(); }
 
         MSGPACK_DEFINE(data)
     };

--- a/src/helper/network/socket.cpp
+++ b/src/helper/network/socket.cpp
@@ -6,7 +6,6 @@
 #include "socket.hpp"
 #include <cerrno>
 #include <chrono>
-#include <iostream>
 #include <spdlog/spdlog.h>
 #include <stdexcept>
 #include <sys/socket.h>

--- a/src/helper/parameter.cpp
+++ b/src/helper/parameter.cpp
@@ -10,7 +10,7 @@
 
 namespace {
 
-const std::string strtype(int type)
+std::string strtype(int type)
 {
     switch (type) {
     case DDWAF_OBJ_MAP:
@@ -19,6 +19,8 @@ const std::string strtype(int type)
         return "array";
     case DDWAF_OBJ_STRING:
         return "string";
+    default:
+        break;
     }
     return "unknown";
 }
@@ -27,14 +29,9 @@ const std::string strtype(int type)
 
 namespace dds {
 
-parameter::parameter() : parameter_base() {}
+parameter::parameter(const ddwaf_object &arg) { *((ddwaf_object *)this) = arg; }
 
-parameter::parameter(const ddwaf_object &arg) : parameter_base()
-{
-    *((ddwaf_object *)this) = arg;
-}
-
-parameter::parameter(parameter &&other) noexcept : parameter_base()
+parameter::parameter(parameter &&other) noexcept
 {
     *((ddwaf_object *)this) = *other;
     ddwaf_object_invalid(other);
@@ -119,6 +116,7 @@ parameter &parameter::operator[](size_t index) const
                                 ")");
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     return static_cast<parameter &>(ddwaf_object::array[index]);
 }
 

--- a/src/helper/parameter.cpp
+++ b/src/helper/parameter.cpp
@@ -3,29 +3,27 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#include "exception.hpp"
 #include "parameter.hpp"
+#include "exception.hpp"
 
 #include <iostream>
 
-namespace
-{
+namespace {
 
 const std::string strtype(int type)
 {
-    switch (type)
-    {
-        case DDWAF_OBJ_MAP:
-            return "map";
-        case DDWAF_OBJ_ARRAY:
-            return "array";
-        case DDWAF_OBJ_STRING:
-            return "string";
+    switch (type) {
+    case DDWAF_OBJ_MAP:
+        return "map";
+    case DDWAF_OBJ_ARRAY:
+        return "array";
+    case DDWAF_OBJ_STRING:
+        return "string";
     }
     return "unknown";
 }
 
-}
+} // namespace
 
 namespace dds {
 
@@ -113,14 +111,15 @@ bool parameter::add(std::string_view name, parameter &&entry) noexcept
     return true;
 }
 
-parameter& parameter::operator[](size_t index) const
+parameter &parameter::operator[](size_t index) const
 {
     if (!is_container() || index >= size()) {
         throw std::out_of_range("index(" + std::to_string(index) +
-                ") out of range(" + std::to_string(size()) + ")");
+                                ") out of range(" + std::to_string(size()) +
+                                ")");
     }
 
-    return static_cast<parameter&>(ddwaf_object::array[index]);
+    return static_cast<parameter &>(ddwaf_object::array[index]);
 }
 
 } // namespace dds

--- a/src/helper/parameter.cpp
+++ b/src/helper/parameter.cpp
@@ -6,25 +6,6 @@
 #include "parameter.hpp"
 #include "exception.hpp"
 
-namespace {
-
-std::string strtype(int type)
-{
-    switch (type) {
-    case DDWAF_OBJ_MAP:
-        return "map";
-    case DDWAF_OBJ_ARRAY:
-        return "array";
-    case DDWAF_OBJ_STRING:
-        return "string";
-    default:
-        break;
-    }
-    return "unknown";
-}
-
-} // namespace
-
 namespace dds {
 
 parameter::parameter(const ddwaf_object &arg) { *((ddwaf_object *)this) = arg; }

--- a/src/helper/parameter.cpp
+++ b/src/helper/parameter.cpp
@@ -8,7 +8,10 @@
 
 namespace dds {
 
-parameter::parameter(const ddwaf_object &arg) { *((ddwaf_object *)this) = arg; }
+parameter::parameter(const ddwaf_object &arg)
+{
+    *static_cast<ddwaf_object *>(this) = arg;
+}
 
 parameter::parameter(parameter &&other) noexcept
 {

--- a/src/helper/parameter.cpp
+++ b/src/helper/parameter.cpp
@@ -3,57 +3,51 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#include "parameter.hpp"
-#include "ddwaf.h"
 #include "exception.hpp"
-#include <string>
-#include <string_view>
+#include "parameter.hpp"
+
+#include <iostream>
+
+namespace
+{
+
+const std::string strtype(int type)
+{
+    switch (type)
+    {
+        case DDWAF_OBJ_MAP:
+            return "map";
+        case DDWAF_OBJ_ARRAY:
+            return "array";
+        case DDWAF_OBJ_STRING:
+            return "string";
+    }
+    return "unknown";
+}
+
+}
 
 namespace dds {
 
-parameter::parameter() : _ddwaf_object() { ddwaf_object_invalid(this); }
+parameter::parameter() : parameter_base() {}
 
-parameter::parameter(const ddwaf_object &arg) : _ddwaf_object()
+parameter::parameter(const ddwaf_object &arg) : parameter_base()
 {
     *((ddwaf_object *)this) = arg;
 }
 
-parameter::parameter(parameter &&other) noexcept : _ddwaf_object()
+parameter::parameter(parameter &&other) noexcept : parameter_base()
 {
-    *((ddwaf_object *)this) = *other.ptr();
-    ddwaf_object_invalid(other.ptr());
+    *((ddwaf_object *)this) = *other;
+    ddwaf_object_invalid(other);
 }
 
 parameter &parameter::operator=(parameter &&other) noexcept
 {
-    *((ddwaf_object *)this) = *other.ptr();
-    ddwaf_object_invalid(other.ptr());
+    *((ddwaf_object *)this) = *other;
+    ddwaf_object_invalid(other);
     return *this;
 }
-
-parameter::parameter(uint64_t value) : _ddwaf_object()
-{
-    ddwaf_object_unsigned(this, value);
-}
-
-parameter::parameter(int64_t value) : _ddwaf_object()
-{
-    ddwaf_object_signed(this, value);
-}
-
-parameter::parameter(const std::string &str) : _ddwaf_object()
-{
-    length_type length = str.length() <= max_length ? str.length() : max_length;
-    ddwaf_object_stringl(this, str.c_str(), length);
-}
-
-parameter::parameter(std::string_view str) : _ddwaf_object()
-{
-    length_type length = str.length() <= max_length ? str.length() : max_length;
-    ddwaf_object_stringl(this, str.data(), length);
-}
-
-void parameter::free() noexcept { ddwaf_object_free(this); }
 
 parameter parameter::map() noexcept
 {
@@ -69,107 +63,64 @@ parameter parameter::array() noexcept
     return parameter{obj};
 }
 
-bool parameter::add(parameter &entry) noexcept
+parameter parameter::uint64(uint64_t value) noexcept
 {
-    return ddwaf_object_array_add(this, entry.ptr());
+    ddwaf_object obj;
+    ddwaf_object_unsigned(&obj, value);
+    return parameter{obj};
 }
+
+parameter parameter::int64(int64_t value) noexcept
+{
+    ddwaf_object obj;
+    ddwaf_object_signed(&obj, value);
+    return parameter{obj};
+}
+
+parameter parameter::string(const std::string &str) noexcept
+{
+    length_type length = str.length() <= max_length ? str.length() : max_length;
+    ddwaf_object obj;
+    ddwaf_object_stringl(&obj, str.c_str(), length);
+    return parameter{obj};
+}
+
+parameter parameter::string(std::string_view str) noexcept
+{
+    length_type length = str.length() <= max_length ? str.length() : max_length;
+    ddwaf_object obj;
+    ddwaf_object_stringl(&obj, str.data(), length);
+    return parameter{obj};
+}
+
 bool parameter::add(parameter &&entry) noexcept
 {
-    if (!ddwaf_object_array_add(this, entry.ptr())) {
-        entry.free();
+    if (!ddwaf_object_array_add(this, entry)) {
         return false;
     }
+    ddwaf_object_invalid(entry);
     return true;
-}
-bool parameter::add(std::string_view name, parameter &entry) noexcept
-{
-    length_type length =
-        name.length() <= max_length ? name.length() : max_length;
-    return ddwaf_object_map_addl(this, name.data(), length, entry.ptr());
 }
 
 bool parameter::add(std::string_view name, parameter &&entry) noexcept
 {
     length_type length =
         name.length() <= max_length ? name.length() : max_length;
-    if (!ddwaf_object_map_addl(this, name.data(), length, entry.ptr())) {
-        entry.free();
+    if (!ddwaf_object_map_addl(this, name.data(), length, entry)) {
         return false;
     }
+    ddwaf_object_invalid(entry);
     return true;
 }
 
-ddwaf_object *parameter::ptr() noexcept { return this; }
-
-parameter parameter::operator[](size_t index) const noexcept
+parameter& parameter::operator[](size_t index) const
 {
     if (!is_container() || index >= size()) {
-        return {};
+        throw std::out_of_range("index(" + std::to_string(index) +
+                ") out of range(" + std::to_string(size()) + ")");
     }
 
-    return parameter{ddwaf_object::array[index]};
+    return static_cast<parameter&>(ddwaf_object::array[index]);
 }
 
-parameter::operator std::string_view() const noexcept
-{
-    if (type != DDWAF_OBJ_STRING || stringValue == nullptr) {
-        return {};
-    }
-
-    return {stringValue, nbEntries};
-}
-
-namespace {
-// NOLINTNEXTLINE(misc-no-recursion,google-runtime-references)
-void debug_str_helper(std::string &res, const parameter &p) noexcept
-{
-    if (p.parameterNameLength != 0U) {
-        res += p.key();
-        res += ": ";
-    }
-    switch (p.type) {
-    case DDWAF_OBJ_INVALID:
-        res += "<invalid>";
-        break;
-    case DDWAF_OBJ_SIGNED:
-        res += std::to_string(p.intValue);
-        break;
-    case DDWAF_OBJ_UNSIGNED:
-        res += std::to_string(p.uintValue);
-        break;
-    case DDWAF_OBJ_STRING:
-        res += '"';
-        res += std::string_view{p.stringValue, p.nbEntries};
-        res += '"';
-        break;
-    case DDWAF_OBJ_ARRAY:
-        res += '[';
-        for (decltype(p.size()) i = 0; i < p.size(); i++) {
-            debug_str_helper(res, p[i]);
-            if (i != p.size() - 1) {
-                res += ", ";
-            }
-        }
-        res += ']';
-        break;
-    case DDWAF_OBJ_MAP:
-        res += '{';
-        for (decltype(p.size()) i = 0; i < p.size(); i++) {
-            debug_str_helper(res, p[i]);
-            if (i != p.size() - 1) {
-                res += ", ";
-            }
-        }
-        res += '}';
-        break;
-    }
-}
-} // namespace
-
-std::string parameter::debug_str() const noexcept
-{
-    std::string res;
-    debug_str_helper(res, *this);
-    return res;
-}
 } // namespace dds

--- a/src/helper/parameter.cpp
+++ b/src/helper/parameter.cpp
@@ -110,12 +110,15 @@ bool parameter::add(std::string_view name, parameter &&entry) noexcept
 
 parameter &parameter::operator[](size_t index) const
 {
-    if (!is_container() || index >= size()) {
+    if (!is_container()) {
+        throw invalid_type("parameter not a container");
+    }
+
+    if (index >= size()) {
         throw std::out_of_range("index(" + std::to_string(index) +
                                 ") out of range(" + std::to_string(size()) +
                                 ")");
     }
-
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     return static_cast<parameter &>(ddwaf_object::array[index]);
 }

--- a/src/helper/parameter.cpp
+++ b/src/helper/parameter.cpp
@@ -6,8 +6,6 @@
 #include "parameter.hpp"
 #include "exception.hpp"
 
-#include <iostream>
-
 namespace {
 
 std::string strtype(int type)

--- a/src/helper/parameter.hpp
+++ b/src/helper/parameter.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <limits>
 #include <string>
 #include <string_view>

--- a/src/helper/parameter.hpp
+++ b/src/helper/parameter.hpp
@@ -1,85 +1,46 @@
-// Unless explicitly stated otherwise all files in this repository are
-// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
-//
-// This product includes software developed at Datadog
-// (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef PARAMETER_HPP
-#define PARAMETER_HPP
+#pragma once
 
-#include <ddwaf.h>
+#include <iostream>
 #include <limits>
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "parameter_base.hpp"
 
 namespace dds {
 
-class parameter : public ddwaf_object {
+class parameter : public parameter_base {
 public:
     parameter();
     explicit parameter(const ddwaf_object &arg);
 
-    // FIXME: Copy and move semantics are unclear, perhaps copy should be
-    //        deleted and move reimplemented to invalidate source parameter.
     parameter(const parameter &) = delete;            // fault;
     parameter &operator=(const parameter &) = delete; // fault;
 
     parameter(parameter &&) noexcept;
     parameter &operator=(parameter &&) noexcept;
 
-    explicit parameter(uint64_t value);
-    explicit parameter(int64_t value);
-    explicit parameter(const std::string &str);
-    explicit parameter(std::string_view str);
-
     // These will be freed by the WAF, if the parameters are not passed to the
     // WAF, expect a memory leak if "free" is not called.
-    ~parameter() = default;
-    void free() noexcept;
-    void invalidate() noexcept { ddwaf_object_invalid(this); }
+    ~parameter() override {
+        ddwaf_object_free(this);
+    }
 
     static parameter map() noexcept;
     static parameter array() noexcept;
+    static parameter uint64(uint64_t value) noexcept;
+    static parameter int64(int64_t value) noexcept;
+    static parameter string(const std::string &str) noexcept;
+    static parameter string(std::string_view str) noexcept;
 
-    // NOLINTNEXTLINE(google-runtime-references)
-    bool add(parameter &entry) noexcept;
-    // NOLINTNEXTLINE(google-runtime-references)
     bool add(parameter &&entry) noexcept;
-    // NOLINTNEXTLINE(google-runtime-references)
-    bool add(std::string_view name, parameter &entry) noexcept;
-    // NOLINTNEXTLINE(google-runtime-references)
     bool add(std::string_view name, parameter &&entry) noexcept;
 
-    // Container size
-    [[nodiscard]] size_t size() const noexcept
-    {
-        return static_cast<size_t>(nbEntries);
-    }
-    parameter operator[](size_t index) const noexcept;
-
-    explicit operator std::string_view() const noexcept;
-
-    [[nodiscard]] std::string_view key() const noexcept
-    {
-        return {parameterName, parameterNameLength};
-    };
-    [[nodiscard]] bool is_map() const noexcept { return type == DDWAF_OBJ_MAP; }
-    [[nodiscard]] bool is_container() const noexcept
-    {
-        return (type & (DDWAF_OBJ_MAP | DDWAF_OBJ_ARRAY)) != 0;
-    }
-    [[nodiscard]] bool is_valid() const noexcept
-    {
-        return type != DDWAF_OBJ_INVALID;
-    }
-    ddwaf_object *ptr() noexcept;
-
-    [[nodiscard]] std::string debug_str() const noexcept;
-
-    using length_type = decltype(nbEntries);
-    static constexpr auto max_length{
-        std::numeric_limits<length_type>::max() - 1};
+    // The reference should be considered invalid after adding an element
+    parameter& operator[](size_t index) const;
 };
 
 } // namespace dds
-
-#endif

--- a/src/helper/parameter.hpp
+++ b/src/helper/parameter.hpp
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
 #pragma once
 
 #include <iostream>
@@ -25,9 +31,7 @@ public:
 
     // These will be freed by the WAF, if the parameters are not passed to the
     // WAF, expect a memory leak if "free" is not called.
-    ~parameter() override {
-        ddwaf_object_free(this);
-    }
+    ~parameter() override { ddwaf_object_free(this); }
 
     static parameter map() noexcept;
     static parameter array() noexcept;
@@ -40,7 +44,7 @@ public:
     bool add(std::string_view name, parameter &&entry) noexcept;
 
     // The reference should be considered invalid after adding an element
-    parameter& operator[](size_t index) const;
+    parameter &operator[](size_t index) const;
 };
 
 } // namespace dds

--- a/src/helper/parameter.hpp
+++ b/src/helper/parameter.hpp
@@ -22,13 +22,20 @@ public:
     parameter() = default;
     explicit parameter(const ddwaf_object &arg);
 
+    template <typename T,
+        typename = std::enable_if_t<std::conjunction_v<
+            std::is_base_of<ddwaf_object, std::remove_cv_t<std::decay_t<T>>>,
+            std::negation<std::is_same<ddwaf_object,
+                std::remove_cv_t<std::decay_t<T>>>>>>>
+    parameter(T &&t) = delete;
+
     parameter(const parameter &) = delete;
     parameter &operator=(const parameter &) = delete;
 
     parameter(parameter &&) noexcept;
     parameter &operator=(parameter &&) noexcept;
 
-    ~parameter() override { ddwaf_object_free(this); }
+    ~parameter() { ddwaf_object_free(this); }
 
     static parameter map() noexcept;
     static parameter array() noexcept;

--- a/src/helper/parameter.hpp
+++ b/src/helper/parameter.hpp
@@ -20,7 +20,7 @@ namespace dds {
 
 class parameter : public parameter_base {
 public:
-    parameter();
+    parameter() = default;
     explicit parameter(const ddwaf_object &arg);
 
     parameter(const parameter &) = delete;            // fault;

--- a/src/helper/parameter.hpp
+++ b/src/helper/parameter.hpp
@@ -22,14 +22,12 @@ public:
     parameter() = default;
     explicit parameter(const ddwaf_object &arg);
 
-    parameter(const parameter &) = delete;            // fault;
-    parameter &operator=(const parameter &) = delete; // fault;
+    parameter(const parameter &) = delete;
+    parameter &operator=(const parameter &) = delete;
 
     parameter(parameter &&) noexcept;
     parameter &operator=(parameter &&) noexcept;
 
-    // These will be freed by the WAF, if the parameters are not passed to the
-    // WAF, expect a memory leak if "free" is not called.
     ~parameter() override { ddwaf_object_free(this); }
 
     static parameter map() noexcept;

--- a/src/helper/parameter_base.cpp
+++ b/src/helper/parameter_base.cpp
@@ -14,44 +14,42 @@ namespace dds {
 
 namespace {
 // NOLINTNEXTLINE(misc-no-recursion,google-runtime-references)
-void debug_str_helper(std::string &res, const parameter_base &p)
+void debug_str_helper(std::string &res, const ddwaf_object &p)
 {
     if (p.parameterNameLength != 0U) {
-        res += p.key();
+        res += p.parameterName;
         res += ": ";
     }
-    switch (p.type()) {
-    case parameter_type::invalid:
+    switch (p.type) {
+    case DDWAF_OBJ_INVALID:
         res += "<invalid>";
         break;
-    case parameter_type::int64:
+    case DDWAF_OBJ_SIGNED:
         res += std::to_string(p.intValue);
         break;
-    case parameter_type::uint64:
+    case DDWAF_OBJ_UNSIGNED:
         res += std::to_string(p.uintValue);
         break;
-    case parameter_type::string:
+    case DDWAF_OBJ_STRING:
         res += '"';
         res += std::string_view{p.stringValue, p.nbEntries};
         res += '"';
         break;
-    case parameter_type::array:
+    case DDWAF_OBJ_ARRAY:
         res += '[';
         for (decltype(p.nbEntries) i = 0; i < p.nbEntries; i++) {
-            debug_str_helper(
-                res, static_cast<const parameter_base &>(p.array[i]));
-            if (i != p.size() - 1) {
+            debug_str_helper(res, p.array[i]);
+            if (i != p.nbEntries - 1) {
                 res += ", ";
             }
         }
         res += ']';
         break;
-    case parameter_type::map:
+    case DDWAF_OBJ_MAP:
         res += '{';
         for (decltype(p.nbEntries) i = 0; i < p.nbEntries; i++) {
-            debug_str_helper(
-                res, static_cast<const parameter_base &>(p.array[i]));
-            if (i != p.size() - 1) {
+            debug_str_helper(res, p.array[i]);
+            if (i != p.nbEntries - 1) {
                 res += ", ";
             }
         }

--- a/src/helper/parameter_base.cpp
+++ b/src/helper/parameter_base.cpp
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
 #include <limits>
 #include <string>
 #include <string_view>
@@ -32,7 +38,8 @@ void debug_str_helper(std::string &res, const parameter_base &p)
     case parameter_type::array:
         res += '[';
         for (decltype(p.nbEntries) i = 0; i < p.nbEntries; i++) {
-            debug_str_helper(res, static_cast<const parameter_base&>(p.array[i]));
+            debug_str_helper(
+                res, static_cast<const parameter_base &>(p.array[i]));
             if (i != p.size() - 1) {
                 res += ", ";
             }
@@ -42,7 +49,8 @@ void debug_str_helper(std::string &res, const parameter_base &p)
     case parameter_type::map:
         res += '{';
         for (decltype(p.nbEntries) i = 0; i < p.nbEntries; i++) {
-            debug_str_helper(res, static_cast<const parameter_base&>(p.array[i]));
+            debug_str_helper(
+                res, static_cast<const parameter_base &>(p.array[i]));
             if (i != p.size() - 1) {
                 res += ", ";
             }
@@ -60,4 +68,4 @@ std::string parameter_base::debug_str() const noexcept
     return res;
 }
 
-}
+} // namespace dds

--- a/src/helper/parameter_base.cpp
+++ b/src/helper/parameter_base.cpp
@@ -1,0 +1,63 @@
+#include <limits>
+#include <string>
+#include <string_view>
+
+#include "parameter_base.hpp"
+
+namespace dds {
+
+namespace {
+// NOLINTNEXTLINE(misc-no-recursion,google-runtime-references)
+void debug_str_helper(std::string &res, const parameter_base &p)
+{
+    if (p.parameterNameLength != 0U) {
+        res += p.key();
+        res += ": ";
+    }
+    switch (p.type()) {
+    case parameter_type::invalid:
+        res += "<invalid>";
+        break;
+    case parameter_type::int64:
+        res += std::to_string(p.intValue);
+        break;
+    case parameter_type::uint64:
+        res += std::to_string(p.uintValue);
+        break;
+    case parameter_type::string:
+        res += '"';
+        res += std::string_view{p.stringValue, p.nbEntries};
+        res += '"';
+        break;
+    case parameter_type::array:
+        res += '[';
+        for (decltype(p.nbEntries) i = 0; i < p.nbEntries; i++) {
+            debug_str_helper(res, static_cast<const parameter_base&>(p.array[i]));
+            if (i != p.size() - 1) {
+                res += ", ";
+            }
+        }
+        res += ']';
+        break;
+    case parameter_type::map:
+        res += '{';
+        for (decltype(p.nbEntries) i = 0; i < p.nbEntries; i++) {
+            debug_str_helper(res, static_cast<const parameter_base&>(p.array[i]));
+            if (i != p.size() - 1) {
+                res += ", ";
+            }
+        }
+        res += '}';
+        break;
+    }
+}
+} // namespace
+
+std::string parameter_base::debug_str() const noexcept
+{
+    std::string res;
+    debug_str_helper(res, *this);
+    return res;
+}
+
+}

--- a/src/helper/parameter_base.hpp
+++ b/src/helper/parameter_base.hpp
@@ -1,24 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
 #pragma once
 
-#include <ddwaf.h>
 #include "exception.hpp"
+#include <ddwaf.h>
 
 namespace dds {
 
 enum parameter_type : unsigned {
     invalid = DDWAF_OBJ_INVALID,
-    int64   = DDWAF_OBJ_SIGNED,
-    uint64  = DDWAF_OBJ_UNSIGNED,
-    string  = DDWAF_OBJ_STRING,
-    map     = DDWAF_OBJ_MAP,
-    array   = DDWAF_OBJ_ARRAY
+    int64 = DDWAF_OBJ_SIGNED,
+    uint64 = DDWAF_OBJ_UNSIGNED,
+    string = DDWAF_OBJ_STRING,
+    map = DDWAF_OBJ_MAP,
+    array = DDWAF_OBJ_ARRAY
 };
 
 class parameter_base : public ddwaf_object {
 public:
-    parameter_base() {
-        ddwaf_object_invalid(this);
-    }
+    parameter_base() { ddwaf_object_invalid(this); }
 
     virtual ~parameter_base() = default;
 
@@ -29,12 +33,16 @@ public:
     }
     [[nodiscard]] size_t size() const noexcept
     {
-        if (!is_container()) { return 0; }
+        if (!is_container()) {
+            return 0;
+        }
         return static_cast<size_t>(nbEntries);
     }
     [[nodiscard]] size_t length() const noexcept
     {
-        if (!is_string()) { return 0; }
+        if (!is_string()) {
+            return 0;
+        }
         return static_cast<size_t>(nbEntries);
     }
     [[nodiscard]] bool has_key() const noexcept
@@ -70,27 +78,31 @@ public:
         return ddwaf_object::type != DDWAF_OBJ_INVALID;
     }
 
-    operator ddwaf_object*() noexcept { return this; }
+    operator ddwaf_object *() noexcept { return this; }
 
-    operator std::string_view() const {
+    operator std::string_view() const
+    {
         if (!is_string()) {
             throw bad_cast("parameter not a string");
         }
         return std::string_view(stringValue, nbEntries);
     }
-    operator std::string() const {
+    operator std::string() const
+    {
         if (!is_string()) {
             throw bad_cast("parameter not a string");
         }
         return std::string(stringValue, nbEntries);
     }
-    operator uint64_t() const {
+    operator uint64_t() const
+    {
         if (!is_unsigned()) {
             throw bad_cast("parameter not an uint64");
         }
         return uintValue;
     }
-    operator int64_t() const {
+    operator int64_t() const
+    {
         if (!is_signed()) {
             throw bad_cast("parameter not an int64");
         }
@@ -104,4 +116,4 @@ public:
         std::numeric_limits<length_type>::max() - 1};
 };
 
-}
+} // namespace dds

--- a/src/helper/parameter_base.hpp
+++ b/src/helper/parameter_base.hpp
@@ -8,6 +8,7 @@
 
 #include "exception.hpp"
 #include <ddwaf.h>
+#include <limits>
 
 namespace dds {
 
@@ -22,12 +23,18 @@ enum parameter_type : unsigned {
 
 class parameter_base : public ddwaf_object {
 public:
-    parameter_base() { ddwaf_object_invalid(this); }
+    parameter_base() : ddwaf_object() { ddwaf_object_invalid(this); }
+
+    parameter_base(const parameter_base &) = default;
+    parameter_base &operator=(const parameter_base &) = default;
+
+    parameter_base(parameter_base &&) = default;
+    parameter_base &operator=(parameter_base &&) = default;
 
     virtual ~parameter_base() = default;
 
     // Container size
-    parameter_type type() const noexcept
+    [[nodiscard]] parameter_type type() const noexcept
     {
         return static_cast<parameter_type>(ddwaf_object::type);
     }
@@ -77,31 +84,31 @@ public:
     {
         return ddwaf_object::type != DDWAF_OBJ_INVALID;
     }
-
+    // NOLINTNEXTLINE
     operator ddwaf_object *() noexcept { return this; }
 
-    operator std::string_view() const
+    explicit operator std::string_view() const
     {
         if (!is_string()) {
             throw bad_cast("parameter not a string");
         }
-        return std::string_view(stringValue, nbEntries);
+        return {stringValue, nbEntries};
     }
-    operator std::string() const
+    explicit operator std::string() const
     {
         if (!is_string()) {
             throw bad_cast("parameter not a string");
         }
-        return std::string(stringValue, nbEntries);
+        return {stringValue, nbEntries};
     }
-    operator uint64_t() const
+    explicit operator uint64_t() const
     {
         if (!is_unsigned()) {
             throw bad_cast("parameter not an uint64");
         }
         return uintValue;
     }
-    operator int64_t() const
+    explicit operator int64_t() const
     {
         if (!is_signed()) {
             throw bad_cast("parameter not an int64");

--- a/src/helper/parameter_base.hpp
+++ b/src/helper/parameter_base.hpp
@@ -8,8 +8,6 @@
 
 #include "exception.hpp"
 #include <ddwaf.h>
-
-#include <iostream>
 #include <limits>
 
 namespace dds {

--- a/src/helper/parameter_base.hpp
+++ b/src/helper/parameter_base.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <ddwaf.h>
+#include "exception.hpp"
+
+namespace dds {
+
+enum parameter_type : unsigned {
+    invalid = DDWAF_OBJ_INVALID,
+    int64   = DDWAF_OBJ_SIGNED,
+    uint64  = DDWAF_OBJ_UNSIGNED,
+    string  = DDWAF_OBJ_STRING,
+    map     = DDWAF_OBJ_MAP,
+    array   = DDWAF_OBJ_ARRAY
+};
+
+class parameter_base : public ddwaf_object {
+public:
+    parameter_base() {
+        ddwaf_object_invalid(this);
+    }
+
+    virtual ~parameter_base() = default;
+
+    // Container size
+    parameter_type type() const noexcept
+    {
+        return static_cast<parameter_type>(ddwaf_object::type);
+    }
+    [[nodiscard]] size_t size() const noexcept
+    {
+        if (!is_container()) { return 0; }
+        return static_cast<size_t>(nbEntries);
+    }
+    [[nodiscard]] size_t length() const noexcept
+    {
+        if (!is_string()) { return 0; }
+        return static_cast<size_t>(nbEntries);
+    }
+    [[nodiscard]] bool has_key() const noexcept
+    {
+        return parameterName != nullptr;
+    }
+    [[nodiscard]] std::string_view key() const noexcept
+    {
+        return {parameterName, parameterNameLength};
+    }
+    [[nodiscard]] bool is_map() const noexcept
+    {
+        return ddwaf_object::type == DDWAF_OBJ_MAP;
+    }
+    [[nodiscard]] bool is_container() const noexcept
+    {
+        return (ddwaf_object::type & (DDWAF_OBJ_MAP | DDWAF_OBJ_ARRAY)) != 0;
+    }
+    [[nodiscard]] bool is_string() const noexcept
+    {
+        return ddwaf_object::type == DDWAF_OBJ_STRING;
+    }
+    [[nodiscard]] bool is_unsigned() const noexcept
+    {
+        return ddwaf_object::type == DDWAF_OBJ_UNSIGNED;
+    }
+    [[nodiscard]] bool is_signed() const noexcept
+    {
+        return ddwaf_object::type == DDWAF_OBJ_SIGNED;
+    }
+    [[nodiscard]] bool is_valid() const noexcept
+    {
+        return ddwaf_object::type != DDWAF_OBJ_INVALID;
+    }
+
+    operator ddwaf_object*() noexcept { return this; }
+
+    operator std::string_view() const {
+        if (!is_string()) {
+            throw bad_cast("parameter not a string");
+        }
+        return std::string_view(stringValue, nbEntries);
+    }
+    operator std::string() const {
+        if (!is_string()) {
+            throw bad_cast("parameter not a string");
+        }
+        return std::string(stringValue, nbEntries);
+    }
+    operator uint64_t() const {
+        if (!is_unsigned()) {
+            throw bad_cast("parameter not an uint64");
+        }
+        return uintValue;
+    }
+    operator int64_t() const {
+        if (!is_signed()) {
+            throw bad_cast("parameter not an int64");
+        }
+        return intValue;
+    }
+
+    [[nodiscard]] std::string debug_str() const noexcept;
+
+    using length_type = decltype(nbEntries);
+    static constexpr auto max_length{
+        std::numeric_limits<length_type>::max() - 1};
+};
+
+}

--- a/src/helper/parameter_base.hpp
+++ b/src/helper/parameter_base.hpp
@@ -31,7 +31,7 @@ public:
     parameter_base(parameter_base &&) = default;
     parameter_base &operator=(parameter_base &&) = default;
 
-    virtual ~parameter_base() = default;
+    ~parameter_base() = default;
 
     // Container size
     [[nodiscard]] parameter_type type() const noexcept

--- a/src/helper/parameter_base.hpp
+++ b/src/helper/parameter_base.hpp
@@ -8,6 +8,8 @@
 
 #include "exception.hpp"
 #include <ddwaf.h>
+
+#include <iostream>
 #include <limits>
 
 namespace dds {

--- a/src/helper/parameter_view.hpp
+++ b/src/helper/parameter_view.hpp
@@ -26,7 +26,8 @@ public:
     class iterator {
     public:
         explicit iterator(const parameter_view &pv, size_t index = 0)
-            : current_(pv.array + (index < pv.nbEntries ? index : pv.nbEntries)),
+            : current_(
+                  pv.array + (index < pv.nbEntries ? index : pv.nbEntries)),
               end_(pv.array + pv.nbEntries)
         {}
 
@@ -63,7 +64,7 @@ public:
     explicit parameter_view(const parameter &arg)
     {
         *(static_cast<ddwaf_object *>(this)) =
-            static_cast<const ddwaf_object&>(arg);
+            static_cast<const ddwaf_object &>(arg);
     }
 
     parameter_view(const parameter_view &) = default;
@@ -89,17 +90,19 @@ public:
         return iterator(*this, size());
     }
 
-    parameter_view& operator[](size_t index) const
+    parameter_view &operator[](size_t index) const
     {
         if (!is_container()) {
             throw invalid_type("parameter not a container");
-        } else if (index >= size()) {
+        }
+
+        if (index >= size()) {
             throw std::out_of_range("index(" + std::to_string(index) +
                                     ") out of range(" + std::to_string(size()) +
                                     ")");
         }
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-        return static_cast<parameter_view&>(ddwaf_object::array[index]);
+        return static_cast<parameter_view &>(ddwaf_object::array[index]);
     }
 };
 

--- a/src/helper/parameter_view.hpp
+++ b/src/helper/parameter_view.hpp
@@ -72,7 +72,7 @@ public:
     parameter_view(parameter_view &&) = delete;
     parameter_view operator=(parameter_view &&) = delete;
 
-    ~parameter_view() override = default;
+    ~parameter_view() = default;
 
     [[nodiscard]] iterator begin() const
     {

--- a/src/helper/parameter_view.hpp
+++ b/src/helper/parameter_view.hpp
@@ -24,7 +24,7 @@ class parameter_view : public parameter_base {
 public:
     class iterator {
     public:
-        iterator(const parameter_view &pv, size_t index = 0)
+        explicit iterator(const parameter_view &pv, size_t index = 0)
             : current_(pv.array + index), end_(pv.array + pv.nbEntries)
         {}
 
@@ -35,6 +35,8 @@ public:
 
         const parameter_view &operator*() const
         {
+
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
             return static_cast<const parameter_view &>(*current_);
         }
 
@@ -51,7 +53,7 @@ public:
         const ddwaf_object *end_{nullptr};
     };
 
-    parameter_view() : parameter_base() {}
+    parameter_view() = default;
     explicit parameter_view(const ddwaf_object &arg)
     {
         *((ddwaf_object *)this) = arg;
@@ -70,14 +72,14 @@ public:
 
     ~parameter_view() override = default;
 
-    iterator begin() const
+    [[nodiscard]] iterator begin() const
     {
         if (!is_container()) {
             throw;
         }
         return iterator(*this);
     }
-    iterator end() const
+    [[nodiscard]] iterator end() const
     {
         if (!is_container()) {
             throw;
@@ -92,6 +94,7 @@ public:
                                     ") out of range(" + std::to_string(size()) +
                                     ")");
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
         return static_cast<parameter_view>(ddwaf_object::array[index]);
     }
 };

--- a/src/helper/parameter_view.hpp
+++ b/src/helper/parameter_view.hpp
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
 #pragma once
 
 #include <iostream>
@@ -18,18 +24,22 @@ class parameter_view : public parameter_base {
 public:
     class iterator {
     public:
-        iterator(const parameter_view &pv, size_t index = 0):
-            current_(pv.array+index),end_(pv.array+pv.nbEntries) {}
+        iterator(const parameter_view &pv, size_t index = 0)
+            : current_(pv.array + index), end_(pv.array + pv.nbEntries)
+        {}
 
-        bool operator!=(const iterator &rhs) const noexcept {
+        bool operator!=(const iterator &rhs) const noexcept
+        {
             return current_ != rhs.current_;
         }
 
-        const parameter_view& operator*() const {
-            return static_cast<const parameter_view&>(*current_);
+        const parameter_view &operator*() const
+        {
+            return static_cast<const parameter_view &>(*current_);
         }
 
-        iterator & operator++() noexcept {
+        iterator &operator++() noexcept
+        {
             if (current_ != end_) {
                 current_++;
             }
@@ -42,19 +52,21 @@ public:
     };
 
     parameter_view() : parameter_base() {}
-    explicit parameter_view(const ddwaf_object &arg) {
+    explicit parameter_view(const ddwaf_object &arg)
+    {
         *((ddwaf_object *)this) = arg;
     }
 
-    explicit parameter_view(const parameter &arg) {
-        *((ddwaf_object *)this) = (const ddwaf_object&)arg;
+    explicit parameter_view(const parameter &arg)
+    {
+        *((ddwaf_object *)this) = (const ddwaf_object &)arg;
     }
 
     parameter_view(const parameter_view &) = default;
     parameter_view &operator=(const parameter_view &) = default;
 
-    parameter_view(parameter_view&&) = delete;
-    parameter_view operator=(parameter_view&&) = delete;
+    parameter_view(parameter_view &&) = delete;
+    parameter_view operator=(parameter_view &&) = delete;
 
     ~parameter_view() override = default;
 
@@ -77,12 +89,11 @@ public:
     {
         if (!is_container() || index >= size()) {
             throw std::out_of_range("index(" + std::to_string(index) +
-                    ") out of range(" + std::to_string(size()) + ")");
+                                    ") out of range(" + std::to_string(size()) +
+                                    ")");
         }
         return static_cast<parameter_view>(ddwaf_object::array[index]);
     }
-
-
 };
 
 } // namespace dds

--- a/src/helper/parameter_view.hpp
+++ b/src/helper/parameter_view.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "parameter.hpp"
+#include "parameter_base.hpp"
+
+namespace dds {
+
+class parameter_view : public parameter_base {
+public:
+    class iterator {
+    public:
+        iterator(const parameter_view &pv, size_t index = 0):
+            current_(pv.array+index),end_(pv.array+pv.nbEntries) {}
+
+        bool operator!=(const iterator &rhs) const noexcept {
+            return current_ != rhs.current_;
+        }
+
+        const parameter_view& operator*() const {
+            return static_cast<const parameter_view&>(*current_);
+        }
+
+        iterator & operator++() noexcept {
+            if (current_ != end_) {
+                current_++;
+            }
+            return *this;
+        }
+
+    protected:
+        const ddwaf_object *current_{nullptr};
+        const ddwaf_object *end_{nullptr};
+    };
+
+    parameter_view() : parameter_base() {}
+    explicit parameter_view(const ddwaf_object &arg) {
+        *((ddwaf_object *)this) = arg;
+    }
+
+    explicit parameter_view(const parameter &arg) {
+        *((ddwaf_object *)this) = (const ddwaf_object&)arg;
+    }
+
+    parameter_view(const parameter_view &) = default;
+    parameter_view &operator=(const parameter_view &) = default;
+
+    parameter_view(parameter_view&&) = delete;
+    parameter_view operator=(parameter_view&&) = delete;
+
+    ~parameter_view() override = default;
+
+    iterator begin() const
+    {
+        if (!is_container()) {
+            throw;
+        }
+        return iterator(*this);
+    }
+    iterator end() const
+    {
+        if (!is_container()) {
+            throw;
+        }
+        return iterator(*this, size());
+    }
+
+    parameter_view operator[](size_t index) const
+    {
+        if (!is_container() || index >= size()) {
+            throw std::out_of_range("index(" + std::to_string(index) +
+                    ") out of range(" + std::to_string(size()) + ")");
+        }
+        return static_cast<parameter_view>(ddwaf_object::array[index]);
+    }
+
+
+};
+
+} // namespace dds

--- a/src/helper/parameter_view.hpp
+++ b/src/helper/parameter_view.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <string>

--- a/src/helper/rate_limit.cpp
+++ b/src/helper/rate_limit.cpp
@@ -7,7 +7,6 @@
 #include "rate_limit.hpp"
 
 #include <chrono>
-#include <iostream>
 #include <limits>
 #include <tuple>
 

--- a/src/helper/result.hpp
+++ b/src/helper/result.hpp
@@ -3,8 +3,7 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef RESULT_HPP
-#define RESULT_HPP
+#pragma once
 
 #include <ostream>
 #include <string>
@@ -31,5 +30,3 @@ struct result {
 };
 
 } // namespace dds
-
-#endif

--- a/src/helper/runner.cpp
+++ b/src/helper/runner.cpp
@@ -96,7 +96,7 @@ void runner::run()
             SPDLOG_DEBUG("new client connected");
 
             worker_pool_.launch(
-                [c](worker::queue_consumer q) mutable { c->run(q); });
+                [c](worker::queue_consumer &q) mutable { c->run(q); });
 
             last_not_idle = std::chrono::steady_clock::now();
         }

--- a/src/helper/runner.cpp
+++ b/src/helper/runner.cpp
@@ -96,7 +96,7 @@ void runner::run()
             SPDLOG_DEBUG("new client connected");
 
             worker_pool_.launch(
-                [c](worker::queue_consumer &q) mutable { c->run(q); });
+                [c](worker::queue_consumer q) mutable { c->run(q); });
 
             last_not_idle = std::chrono::steady_clock::now();
         }

--- a/src/helper/runner.hpp
+++ b/src/helper/runner.hpp
@@ -3,8 +3,7 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef RUNNER_HPP
-#define RUNNER_HPP
+#pragma once
 
 #include <boost/asio.hpp>
 #include <chrono>
@@ -43,4 +42,3 @@ private:
 };
 
 } // namespace dds
-#endif

--- a/src/helper/subscriber/base.hpp
+++ b/src/helper/subscriber/base.hpp
@@ -3,8 +3,7 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef SUBSCRIBER_BASE_HPP
-#define SUBSCRIBER_BASE_HPP
+#pragma once
 
 #include "../client_settings.hpp"
 #include "../parameter.hpp"
@@ -47,4 +46,3 @@ public:
 };
 
 } // namespace dds
-#endif

--- a/src/helper/subscriber/base.hpp
+++ b/src/helper/subscriber/base.hpp
@@ -8,6 +8,7 @@
 
 #include "../client_settings.hpp"
 #include "../parameter.hpp"
+#include "../parameter_view.hpp"
 #include "../result.hpp"
 #include <memory>
 #include <vector>
@@ -30,7 +31,7 @@ public:
 
         virtual ~listener() = default;
         // NOLINTNEXTLINE(google-runtime-references)
-        virtual result call(parameter &data) = 0;
+        virtual result call(parameter_view &data) = 0;
     };
 
     subscriber() = default;

--- a/src/helper/subscriber/waf.cpp
+++ b/src/helper/subscriber/waf.cpp
@@ -217,12 +217,12 @@ instance::listener::~listener()
     }
 }
 
-dds::result instance::listener::call(dds::parameter &data)
+dds::result instance::listener::call(dds::parameter_view &data)
 {
     ddwaf_result res;
     DDWAF_RET_CODE code;
     auto run_waf = [&]() {
-        code = ddwaf_run(handle_, data.ptr(), nullptr, &res, waf_timeout_.count());
+        code = ddwaf_run(handle_, data, nullptr, &res, waf_timeout_.count());
     };
 
     if (spdlog::should_log(spdlog::level::debug)) {
@@ -268,9 +268,8 @@ dds::result instance::listener::call(dds::parameter &data)
 }
 
 instance::instance(parameter &rule, std::uint64_t waf_timeout_us)
-    : handle_{ddwaf_init(rule.ptr(), nullptr, nullptr)}, waf_timeout_{waf_timeout_us}
+    : handle_{ddwaf_init(rule, nullptr, nullptr)}, waf_timeout_{waf_timeout_us}
 {
-    rule.free();
     if (handle_ == nullptr) {
         throw invalid_object();
     }
@@ -336,7 +335,7 @@ parameter parse_string(std::string_view config)
     }
 
     parameter obj;
-    json_to_object(obj.ptr(), document);
+    json_to_object(obj, document);
     return obj;
 }
 

--- a/src/helper/subscriber/waf.cpp
+++ b/src/helper/subscriber/waf.cpp
@@ -222,7 +222,7 @@ dds::result instance::listener::call(dds::parameter_view &data)
     ddwaf_result res;
     DDWAF_RET_CODE code;
     auto run_waf = [&]() {
-        code = ddwaf_run(handle_, data, nullptr, &res, waf_timeout_.count());
+        code = ddwaf_run(handle_, data, &res, waf_timeout_.count());
     };
 
     if (spdlog::should_log(spdlog::level::debug)) {

--- a/src/helper/subscriber/waf.hpp
+++ b/src/helper/subscriber/waf.hpp
@@ -22,6 +22,8 @@ void initialise_logging(spdlog::level::level_enum level);
 
 class instance : public dds::subscriber {
 public:
+    static constexpr int default_waf_timeout_us = 10000;
+
     using ptr = std::shared_ptr<instance>;
     class listener : public dds::subscriber::listener {
     public:
@@ -54,8 +56,8 @@ public:
     static instance::ptr from_settings(const client_settings &settings);
 
     // testing only
-    static instance::ptr from_string(
-        std::string_view rule, std::uint64_t waf_timeout_us = 10000);
+    static instance::ptr from_string(std::string_view rule,
+        std::uint64_t waf_timeout_us = default_waf_timeout_us);
 
 protected:
     ddwaf_handle handle_{nullptr};

--- a/src/helper/subscriber/waf.hpp
+++ b/src/helper/subscriber/waf.hpp
@@ -3,8 +3,7 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-#ifndef WAF_HPP
-#define WAF_HPP
+#pragma once
 
 #include <chrono>
 #include <ddwaf.h>
@@ -68,5 +67,3 @@ parameter parse_file(std::string_view filename);
 parameter parse_string(std::string_view config);
 
 } // namespace dds::waf
-
-#endif // WAF_HPP

--- a/src/helper/subscriber/waf.hpp
+++ b/src/helper/subscriber/waf.hpp
@@ -55,7 +55,7 @@ public:
 
     // testing only
     static instance::ptr from_string(
-        std::string_view rule, std::uint64_t waf_timeout_us);
+        std::string_view rule, std::uint64_t waf_timeout_us = 10000);
 
 protected:
     ddwaf_handle handle_{nullptr};

--- a/src/helper/subscriber/waf.hpp
+++ b/src/helper/subscriber/waf.hpp
@@ -32,7 +32,7 @@ public:
         listener &operator=(listener &&) noexcept;
         ~listener() override;
 
-        dds::result call(dds::parameter &data) override;
+        dds::result call(dds::parameter_view &data) override;
 
     protected:
         ddwaf_context handle_{};

--- a/src/helper/worker_pool.cpp
+++ b/src/helper/worker_pool.cpp
@@ -53,7 +53,8 @@ bool pool::launch(runnable &&f)
     }
 
     if (!q_.push(f)) {
-        std::thread(work_handler, std::move(queue_consumer(q_)), std::move(f)).detach();
+        std::thread(work_handler, std::move(queue_consumer(q_)), std::move(f))
+            .detach();
     }
     return true;
 }

--- a/src/helper/worker_pool.cpp
+++ b/src/helper/worker_pool.cpp
@@ -15,7 +15,7 @@ namespace {
 void work_handler(queue_consumer &&q, std::optional<runnable> &&opt_r)
 {
     while (q.running() && opt_r) {
-        opt_r.value()(std::move(q));
+        opt_r.value()(q);
         opt_r = std::move(q.pop(60s));
     }
 }

--- a/src/helper/worker_pool.hpp
+++ b/src/helper/worker_pool.hpp
@@ -20,7 +20,7 @@ namespace dds::worker {
 
 class queue_consumer;
 
-using runnable = std::function<void(queue_consumer &)>;
+using runnable = std::function<void(queue_consumer)>;
 
 class queue_producer {
 public:

--- a/src/helper/worker_pool.hpp
+++ b/src/helper/worker_pool.hpp
@@ -20,7 +20,7 @@ namespace dds::worker {
 
 class queue_consumer;
 
-using runnable = std::function<void(queue_consumer)>;
+using runnable = std::function<void(queue_consumer &&)>;
 
 class queue_producer {
 public:

--- a/src/helper/worker_pool.hpp
+++ b/src/helper/worker_pool.hpp
@@ -20,7 +20,7 @@ namespace dds::worker {
 
 class queue_consumer;
 
-using runnable = std::function<void(queue_consumer &&)>;
+using runnable = std::function<void(queue_consumer &)>;
 
 class queue_producer {
 public:

--- a/tests/fuzzer/corpus_generator.cpp
+++ b/tests/fuzzer/corpus_generator.cpp
@@ -18,6 +18,7 @@ namespace fs = std:: experimental::filesystem;
 #endif
 
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <random>
 #include <msgpack.hpp>

--- a/tests/helper/broker_test.cpp
+++ b/tests/helper/broker_test.cpp
@@ -6,6 +6,7 @@
 #include "common.hpp"
 #include "version.hpp"
 #include <exception.hpp>
+#include <parameter_view.hpp>
 #include <msgpack.hpp>
 #include <network/broker.hpp>
 #include <network/socket.hpp>
@@ -228,13 +229,13 @@ TEST(BrokerTest, RecvRequestInit)
     EXPECT_STREQ(request.method.c_str(), "request_init");
 
     auto &command = request.as<network::request_init>();
-    EXPECT_TRUE(command.data.is_map());
-    EXPECT_EQ(command.data.size(), 2);
-    EXPECT_STREQ(command.data[0].key().data(), "server.request.query");
-    EXPECT_STREQ(std::string_view(command.data[0]).data(), "Arachni");
-    EXPECT_STREQ(command.data[1].key().data(), "server.request.uri");
-    EXPECT_STREQ(std::string_view(command.data[1]).data(), "arachni.com");
-    command.data.free();
+    parameter_view pv(command.data);
+    EXPECT_TRUE(pv.is_map());
+    EXPECT_EQ(pv.size(), 2);
+    EXPECT_STREQ(pv[0].key().data(), "server.request.query");
+    EXPECT_STREQ(std::string_view(pv[0]).data(), "Arachni");
+    EXPECT_STREQ(pv[1].key().data(), "server.request.uri");
+    EXPECT_STREQ(std::string_view(pv[1]).data(), "arachni.com");
 }
 
 TEST(BrokerTest, RecvRequestShutdown)
@@ -263,11 +264,11 @@ TEST(BrokerTest, RecvRequestShutdown)
     EXPECT_STREQ(request.method.c_str(), "request_shutdown");
 
     auto command = std::move(request.as<network::request_shutdown>());
-    EXPECT_TRUE(command.data.is_map());
-    EXPECT_EQ(command.data.size(), 1);
-    EXPECT_STREQ(command.data[0].key().data(), "server.response.code");
-    EXPECT_STREQ(std::string_view(command.data[0]).data(), "1729");
-    command.data.free();
+    parameter_view pv(command.data);
+    EXPECT_TRUE(pv.is_map());
+    EXPECT_EQ(pv.size(), 1);
+    EXPECT_STREQ(pv[0].key().data(), "server.response.code");
+    EXPECT_STREQ(std::string_view(pv[0]).data(), "1729");
 }
 
 TEST(BrokerTest, NoBytesForHeader)

--- a/tests/helper/broker_test.cpp
+++ b/tests/helper/broker_test.cpp
@@ -6,10 +6,10 @@
 #include "common.hpp"
 #include "version.hpp"
 #include <exception.hpp>
-#include <parameter_view.hpp>
 #include <msgpack.hpp>
 #include <network/broker.hpp>
 #include <network/socket.hpp>
+#include <parameter_view.hpp>
 
 namespace dds {
 

--- a/tests/helper/client_test.cpp
+++ b/tests/helper/client_test.cpp
@@ -245,7 +245,7 @@ TEST(ClientTest, RequestInitOnClientInit)
         network::request_init::request msg;
         msg.data = parameter::map();
         msg.data.add("server.request.headers.no_cookies",
-            parameter("acunetix-product"sv));
+            parameter::string("acunetix-product"sv));
 
         network::request req(std::move(msg));
 
@@ -288,7 +288,7 @@ TEST(ClientTest, RequestInit)
         network::request_init::request msg;
         msg.data = parameter::map();
         msg.data.add("server.request.headers.no_cookies",
-            parameter("acunetix-product"sv));
+            parameter::string("acunetix-product"sv));
 
         network::request req(std::move(msg));
 
@@ -315,7 +315,7 @@ TEST(ClientTest, RequestInitNoClientInit)
         network::request_init::request msg;
         msg.data = parameter::map();
         msg.data.add("server.request.headers.no_cookies",
-            parameter("acunetix-product"sv));
+            parameter::string("acunetix-product"sv));
 
         network::request req(std::move(msg));
 
@@ -399,7 +399,7 @@ TEST(ClientTest, RequestInitBrokerThrows)
         network::request_init::request msg;
         msg.data = parameter::map();
         msg.data.add("server.request.headers.no_cookies",
-            parameter("acunetix-product"sv));
+            parameter::string("acunetix-product"sv));
 
         network::request req(std::move(msg));
 
@@ -414,7 +414,7 @@ TEST(ClientTest, RequestInitBrokerThrows)
         network::request_init::request msg;
         msg.data = parameter::map();
         msg.data.add("server.request.headers.no_cookies",
-            parameter("acunetix-product"sv));
+            parameter::string("acunetix-product"sv));
 
         network::request req(std::move(msg));
 
@@ -458,7 +458,7 @@ TEST(ClientTest, RequestShutdown)
         network::request_init::request msg;
         msg.data = parameter::map();
         msg.data.add(
-            "server.request.headers.no_cookies", parameter("Arachni"sv));
+            "server.request.headers.no_cookies", parameter::string("Arachni"sv));
 
         network::request req(std::move(msg));
 
@@ -476,7 +476,7 @@ TEST(ClientTest, RequestShutdown)
     {
         network::request_shutdown::request msg;
         msg.data = parameter::map();
-        msg.data.add("server.response.code", parameter("1991"sv));
+        msg.data.add("server.response.code", parameter::string("1991"sv));
 
         network::request req(std::move(msg));
 
@@ -523,7 +523,7 @@ TEST(ClientTest, RequestShutdownInvalidData)
         network::request_init::request msg;
         msg.data = parameter::map();
         msg.data.add(
-            "server.request.headers.no_cookies", parameter("Arachni"sv));
+            "server.request.headers.no_cookies", parameter::string("Arachni"sv));
 
         network::request req(std::move(msg));
 
@@ -646,7 +646,7 @@ TEST(ClientTest, RequestShutdownBrokerThrows)
         network::request_init::request msg;
         msg.data = parameter::map();
         msg.data.add(
-            "server.request.headers.no_cookies", parameter("Arachni"sv));
+            "server.request.headers.no_cookies", parameter::string("Arachni"sv));
 
         network::request req(std::move(msg));
 
@@ -664,7 +664,7 @@ TEST(ClientTest, RequestShutdownBrokerThrows)
     {
         network::request_shutdown::request msg;
         msg.data = parameter::map();
-        msg.data.add("server.response.code", parameter("1991"sv));
+        msg.data.add("server.response.code", parameter::string("1991"sv));
 
         network::request req(std::move(msg));
 
@@ -678,7 +678,7 @@ TEST(ClientTest, RequestShutdownBrokerThrows)
     {
         network::request_shutdown::request msg;
         msg.data = parameter::map();
-        msg.data.add("server.response.code", parameter("1991"sv));
+        msg.data.add("server.response.code", parameter::string("1991"sv));
 
         network::request req(std::move(msg));
 

--- a/tests/helper/client_test.cpp
+++ b/tests/helper/client_test.cpp
@@ -457,8 +457,8 @@ TEST(ClientTest, RequestShutdown)
     {
         network::request_init::request msg;
         msg.data = parameter::map();
-        msg.data.add(
-            "server.request.headers.no_cookies", parameter::string("Arachni"sv));
+        msg.data.add("server.request.headers.no_cookies",
+            parameter::string("Arachni"sv));
 
         network::request req(std::move(msg));
 
@@ -522,8 +522,8 @@ TEST(ClientTest, RequestShutdownInvalidData)
     {
         network::request_init::request msg;
         msg.data = parameter::map();
-        msg.data.add(
-            "server.request.headers.no_cookies", parameter::string("Arachni"sv));
+        msg.data.add("server.request.headers.no_cookies",
+            parameter::string("Arachni"sv));
 
         network::request req(std::move(msg));
 
@@ -645,8 +645,8 @@ TEST(ClientTest, RequestShutdownBrokerThrows)
     {
         network::request_init::request msg;
         msg.data = parameter::map();
-        msg.data.add(
-            "server.request.headers.no_cookies", parameter::string("Arachni"sv));
+        msg.data.add("server.request.headers.no_cookies",
+            parameter::string("Arachni"sv));
 
         network::request req(std::move(msg));
 

--- a/tests/helper/engine_test.cpp
+++ b/tests/helper/engine_test.cpp
@@ -18,7 +18,7 @@ class listener : public dds::subscriber::listener {
 public:
     typedef std::shared_ptr<dds::mock::listener> ptr;
 
-    MOCK_METHOD1(call, dds::result(dds::parameter &));
+    MOCK_METHOD1(call, dds::result(dds::parameter_view &));
 };
 
 class subscriber : public dds::subscriber {
@@ -36,7 +36,7 @@ TEST(EngineTest, NoSubscriptors)
     auto ctx = e->get_context();
 
     parameter p = parameter::map();
-    p.add("a", parameter("value"sv));
+    p.add("a", parameter::string("value"sv));
     auto res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::ok);
 }
@@ -59,17 +59,17 @@ TEST(EngineTest, SingleSubscriptor)
     auto ctx = e->get_context();
 
     parameter p = parameter::map();
-    p.add("a", parameter("value"sv));
+    p.add("a", parameter::string("value"sv));
     auto res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::block);
 
     p = parameter::map();
-    p.add("b", parameter("value"sv));
+    p.add("b", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::block);
 
     p = parameter::map();
-    p.add("c", parameter("value"sv));
+    p.add("c", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::ok);
 }
@@ -111,55 +111,55 @@ TEST(EngineTest, MultipleSubscriptors)
     auto ctx = e->get_context();
 
     parameter p = parameter::map();
-    p.add("a", parameter("value"sv));
+    p.add("a", parameter::string("value"sv));
     auto res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::block);
 
     p = parameter::map();
-    p.add("b", parameter("value"sv));
+    p.add("b", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::block);
 
     p = parameter::map();
-    p.add("c", parameter("value"sv));
+    p.add("c", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::record);
 
     p = parameter::map();
-    p.add("d", parameter("value"sv));
+    p.add("d", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::record);
 
     p = parameter::map();
-    p.add("e", parameter("value"sv));
+    p.add("e", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::block);
 
     p = parameter::map();
-    p.add("f", parameter("value"sv));
+    p.add("f", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::block);
 
     p = parameter::map();
-    p.add("g", parameter("value"sv));
+    p.add("g", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::record);
 
     p = parameter::map();
-    p.add("h", parameter("value"sv));
+    p.add("h", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::ok);
 
     p = parameter::map();
-    p.add("a", parameter("value"sv));
-    p.add("c", parameter("value"sv));
-    p.add("h", parameter("value"sv));
+    p.add("a", parameter::string("value"sv));
+    p.add("c", parameter::string("value"sv));
+    p.add("h", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::block);
 
     p = parameter::map();
-    p.add("c", parameter("value"sv));
-    p.add("h", parameter("value"sv));
+    p.add("c", parameter::string("value"sv));
+    p.add("h", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::record);
 }
@@ -189,39 +189,39 @@ TEST(EngineTest, StatefulSubscriptor)
     auto ctx = e->get_context();
 
     parameter p = parameter::map();
-    p.add("sub1", parameter("value"sv));
+    p.add("sub1", parameter::string("value"sv));
     auto res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::ok);
 
     p = parameter::map();
-    p.add("sub2", parameter("value"sv));
+    p.add("sub2", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::ok);
 
     p = parameter::map();
-    p.add("irrelevant", parameter("value"sv));
+    p.add("irrelevant", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::ok);
 
     p = parameter::map();
-    p.add("final", parameter("value"sv));
+    p.add("final", parameter::string("value"sv));
     res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::record);
 
     auto ctx2 = e->get_context();
 
     p = parameter::map();
-    p.add("final", parameter("value"sv));
+    p.add("final", parameter::string("value"sv));
     res = ctx2.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::ok);
 
     p = parameter::map();
-    p.add("sub1", parameter("value"sv));
+    p.add("sub1", parameter::string("value"sv));
     res = ctx2.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::ok);
 
     p = parameter::map();
-    p.add("sub2", parameter("value"sv));
+    p.add("sub2", parameter::string("value"sv));
     res = ctx2.publish(std::move(p));
     EXPECT_EQ(res.value, result::code::record);
 }
@@ -234,8 +234,8 @@ TEST(EngineTest, WafSubscriptorBasic)
     auto ctx = e->get_context();
 
     auto p = parameter::map();
-    p.add("arg1", parameter("string 1"sv));
-    p.add("arg2", parameter("string 3"sv));
+    p.add("arg1", parameter::string("string 1"sv));
+    p.add("arg2", parameter::string("string 3"sv));
 
     auto res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, dds::result::code::record);
@@ -268,8 +268,8 @@ TEST(EngineTest, WafSubscriptorTimeout)
     auto ctx = e->get_context();
 
     auto p = parameter::map();
-    p.add("arg1", parameter("string 1"sv));
-    p.add("arg2", parameter("string 3"sv));
+    p.add("arg1", parameter::string("string 1"sv));
+    p.add("arg2", parameter::string("string 3"sv));
 
     auto res = ctx.publish(std::move(p));
     EXPECT_EQ(res.value, dds::result::code::ok);

--- a/tests/helper/engine_test.cpp
+++ b/tests/helper/engine_test.cpp
@@ -229,7 +229,7 @@ TEST(EngineTest, StatefulSubscriptor)
 TEST(EngineTest, WafSubscriptorBasic)
 {
     auto e{engine::create()};
-    e->subscribe(waf::instance::from_string(waf_rule, 100));
+    e->subscribe(waf::instance::from_string(waf_rule));
 
     auto ctx = e->get_context();
 
@@ -251,7 +251,7 @@ TEST(EngineTest, WafSubscriptorBasic)
 TEST(EngineTest, WafSubscriptorInvalidParam)
 {
     auto e{engine::create()};
-    e->subscribe(waf::instance::from_string(waf_rule, 100));
+    e->subscribe(waf::instance::from_string(waf_rule));
 
     auto ctx = e->get_context();
 

--- a/tests/helper/parameter_test.cpp
+++ b/tests/helper/parameter_test.cpp
@@ -27,7 +27,7 @@ TEST(ParameterTest, UintMaxConstructor)
     parameter p = parameter::uint64(value);
     EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_THROW(p[0], std::out_of_range);
+    EXPECT_THROW(p[0], invalid_type);
 
     EXPECT_NO_THROW(std::string(p));
     EXPECT_NO_THROW(std::string_view(p));
@@ -47,7 +47,7 @@ TEST(ParameterTest, UintMinConstructor)
     parameter p = parameter::uint64(value);
     EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_THROW(p[0], std::out_of_range);
+    EXPECT_THROW(p[0], invalid_type);
 
     EXPECT_NO_THROW(std::string(p));
     EXPECT_NO_THROW(std::string_view(p));
@@ -67,7 +67,7 @@ TEST(ParameterTest, IntMaxConstructor)
     parameter p = parameter::int64(value);
     EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_THROW(p[0], std::out_of_range);
+    EXPECT_THROW(p[0], invalid_type);
 
     EXPECT_NO_THROW(std::string(p));
     EXPECT_NO_THROW(std::string_view(p));
@@ -87,7 +87,7 @@ TEST(ParameterTest, IntMinConstructor)
     parameter p = parameter::int64(value);
     EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_THROW(p[0], std::out_of_range);
+    EXPECT_THROW(p[0], invalid_type);
 
     EXPECT_NO_THROW(std::string(p));
     EXPECT_NO_THROW(std::string_view(p));
@@ -107,10 +107,10 @@ TEST(ParameterTest, StringConstructor)
     parameter p = parameter::string(value);
     EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_EQ(p.length(), value.size());
-    EXPECT_EQ(p.size(), 0); 
+    EXPECT_EQ(p.size(), 0);
 
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_THROW(p[0], std::out_of_range);
+    EXPECT_THROW(p[0], invalid_type);
 
     EXPECT_NO_THROW(std::string(p));
     EXPECT_NO_THROW(std::string_view(p));
@@ -130,7 +130,7 @@ TEST(ParameterTest, StringViewConstructor)
     EXPECT_EQ(p.size(), 0);
 
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_THROW(p[0], std::out_of_range);
+    EXPECT_THROW(p[0], invalid_type);
 
     EXPECT_NO_THROW(std::string(p));
     EXPECT_NO_THROW(std::string_view(p));
@@ -260,7 +260,8 @@ TEST(ParameterTest, StaticCastFromMapObject)
             ddwaf_object_string(&tmp, "value"));
     }
 
-    parameter p = static_cast<parameter>(obj);;
+    parameter p = static_cast<parameter>(obj);
+    ;
     EXPECT_EQ(p.type(), parameter_type::map);
     EXPECT_EQ(p.length(), 0);
     EXPECT_EQ(p.size(), size);
@@ -281,8 +282,8 @@ TEST(ParameterTest, StaticCastFromArrayObject)
     ddwaf_object obj, tmp;
     ddwaf_object_array(&obj);
     for (int i = 0; i < size; i++) {
-        ddwaf_object_array_add(&obj,
-            ddwaf_object_string(&tmp, std::to_string(i).c_str()));
+        ddwaf_object_array_add(
+            &obj, ddwaf_object_string(&tmp, std::to_string(i).c_str()));
     }
 
     parameter p = static_cast<parameter>(obj);
@@ -298,6 +299,5 @@ TEST(ParameterTest, StaticCastFromArrayObject)
 
     EXPECT_THROW(p[size], std::out_of_range);
 }
-
 
 } // namespace dds

--- a/tests/helper/parameter_test.cpp
+++ b/tests/helper/parameter_test.cpp
@@ -29,8 +29,8 @@ TEST(ParameterTest, UintMaxConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], invalid_type);
 
-    EXPECT_NO_THROW(std::string(p));
-    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_NO_THROW(auto s = std::string(p));
+    EXPECT_NO_THROW(auto sv = std::string_view(p));
     EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
     EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 
@@ -49,8 +49,8 @@ TEST(ParameterTest, UintMinConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], invalid_type);
 
-    EXPECT_NO_THROW(std::string(p));
-    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_NO_THROW(auto s = std::string(p));
+    EXPECT_NO_THROW(auto sv = std::string_view(p));
     EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
     EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 
@@ -69,8 +69,8 @@ TEST(ParameterTest, IntMaxConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], invalid_type);
 
-    EXPECT_NO_THROW(std::string(p));
-    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_NO_THROW(auto s = std::string(p));
+    EXPECT_NO_THROW(auto sv = std::string_view(p));
     EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
     EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 
@@ -89,8 +89,8 @@ TEST(ParameterTest, IntMinConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], invalid_type);
 
-    EXPECT_NO_THROW(std::string(p));
-    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_NO_THROW(auto s = std::string(p));
+    EXPECT_NO_THROW(auto sv = std::string_view(p));
     EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
     EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 
@@ -112,8 +112,8 @@ TEST(ParameterTest, StringConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], invalid_type);
 
-    EXPECT_NO_THROW(std::string(p));
-    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_NO_THROW(auto s = std::string(p));
+    EXPECT_NO_THROW(auto sv = std::string_view(p));
     EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
     EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 
@@ -132,8 +132,8 @@ TEST(ParameterTest, StringViewConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], invalid_type);
 
-    EXPECT_NO_THROW(std::string(p));
-    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_NO_THROW(auto s = std::string(p));
+    EXPECT_NO_THROW(auto sv = std::string_view(p));
     EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
     EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 

--- a/tests/helper/parameter_test.cpp
+++ b/tests/helper/parameter_test.cpp
@@ -4,8 +4,8 @@
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 #include "common.hpp"
-#include <parameter.hpp>
 #include <exception.hpp>
+#include <parameter.hpp>
 
 const std::string waf_rule =
     R"({"version":"1.0","events":[{"id":1,"tags":{"type":"flow1"},"conditions":[{"operation":"match_regex","parameters":{"inputs":["arg1"],"regex":"^string.*"}},{"operation":"match_regex","parameters":{"inputs":["arg2"],"regex":".*"}}],"action":"record"}]})";
@@ -22,7 +22,7 @@ TEST(ParameterTest, EmptyConstructor)
 TEST(ParameterTest, UintMaxConstructor)
 {
     uint64_t value = std::numeric_limits<uint64_t>::max();
-    parameter p= parameter::uint64(value);
+    parameter p = parameter::uint64(value);
     EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], std::out_of_range);

--- a/tests/helper/parameter_test.cpp
+++ b/tests/helper/parameter_test.cpp
@@ -7,9 +7,6 @@
 #include <exception.hpp>
 #include <parameter.hpp>
 
-const std::string waf_rule =
-    R"({"version":"1.0","events":[{"id":1,"tags":{"type":"flow1"},"conditions":[{"operation":"match_regex","parameters":{"inputs":["arg1"],"regex":"^string.*"}},{"operation":"match_regex","parameters":{"inputs":["arg2"],"regex":".*"}}],"action":"record"}]})";
-
 namespace dds {
 
 TEST(ParameterTest, EmptyConstructor)
@@ -17,6 +14,11 @@ TEST(ParameterTest, EmptyConstructor)
     parameter p;
     EXPECT_EQ(p.type(), parameter_type::invalid);
     EXPECT_FALSE(p.is_valid());
+
+    EXPECT_THROW(auto s = std::string(p), bad_cast);
+    EXPECT_THROW(auto sv = std::string_view(p), bad_cast);
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 }
 
 TEST(ParameterTest, UintMaxConstructor)
@@ -27,9 +29,16 @@ TEST(ParameterTest, UintMaxConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], std::out_of_range);
 
+    EXPECT_NO_THROW(std::string(p));
+    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
+
     std::stringstream ss;
     ss << value;
-    EXPECT_TRUE(p.stringValue == ss.str());
+    const auto &value_str = ss.str();
+    EXPECT_STREQ(p.stringValue, value_str.c_str());
+    EXPECT_STREQ(std::string_view(p).data(), value_str.c_str());
 }
 
 TEST(ParameterTest, UintMinConstructor)
@@ -40,9 +49,16 @@ TEST(ParameterTest, UintMinConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], std::out_of_range);
 
+    EXPECT_NO_THROW(std::string(p));
+    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
+
     std::stringstream ss;
     ss << value;
-    EXPECT_TRUE(p.stringValue == ss.str());
+    const auto &value_str = ss.str();
+    EXPECT_STREQ(p.stringValue, value_str.c_str());
+    EXPECT_STREQ(std::string_view(p).data(), value_str.c_str());
 }
 
 TEST(ParameterTest, IntMaxConstructor)
@@ -53,9 +69,16 @@ TEST(ParameterTest, IntMaxConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], std::out_of_range);
 
+    EXPECT_NO_THROW(std::string(p));
+    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
+
     std::stringstream ss;
     ss << value;
-    EXPECT_TRUE(p.stringValue == ss.str());
+    const auto &value_str = ss.str();
+    EXPECT_STREQ(p.stringValue, value_str.c_str());
+    EXPECT_STREQ(std::string_view(p).data(), value_str.c_str());
 }
 
 TEST(ParameterTest, IntMinConstructor)
@@ -66,9 +89,16 @@ TEST(ParameterTest, IntMinConstructor)
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], std::out_of_range);
 
+    EXPECT_NO_THROW(std::string(p));
+    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
+
     std::stringstream ss;
     ss << value;
-    EXPECT_TRUE(p.stringValue == ss.str());
+    const auto &value_str = ss.str();
+    EXPECT_STREQ(p.stringValue, value_str.c_str());
+    EXPECT_STREQ(std::string_view(p).data(), value_str.c_str());
 }
 
 TEST(ParameterTest, StringConstructor)
@@ -76,20 +106,39 @@ TEST(ParameterTest, StringConstructor)
     std::string value("thisisastring");
     parameter p = parameter::string(value);
     EXPECT_EQ(p.type(), parameter_type::string);
+    EXPECT_EQ(p.length(), value.size());
+    EXPECT_EQ(p.size(), 0); 
+
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], std::out_of_range);
 
-    EXPECT_TRUE(p.stringValue == value);
+    EXPECT_NO_THROW(std::string(p));
+    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
+
+    EXPECT_STREQ(p.stringValue, value.data());
+    EXPECT_STREQ(std::string_view(p).data(), value.data());
 }
 
 TEST(ParameterTest, StringViewConstructor)
 {
-    parameter p = parameter::string("thisisastring"sv);
+    std::string value("thisisastring");
+    parameter p = parameter::string(value);
     EXPECT_EQ(p.type(), parameter_type::string);
+    EXPECT_EQ(p.length(), value.size());
+    EXPECT_EQ(p.size(), 0);
+
     EXPECT_NE(p.stringValue, nullptr);
     EXPECT_THROW(p[0], std::out_of_range);
 
-    EXPECT_TRUE(p.stringValue == "thisisastring"sv);
+    EXPECT_NO_THROW(std::string(p));
+    EXPECT_NO_THROW(std::string_view(p));
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
+
+    EXPECT_STREQ(p.stringValue, value.data());
+    EXPECT_STREQ(std::string_view(p).data(), value.data());
 }
 
 TEST(ParameterTest, MoveConstructor)
@@ -123,34 +172,43 @@ TEST(ParameterTest, Map)
     parameter p = parameter::map();
     EXPECT_EQ(p.type(), parameter_type::map);
     EXPECT_EQ(p.size(), 0);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_TRUE(p.add("key0", parameter::string("value"sv)));
     EXPECT_STREQ(p[0].key().data(), "key0");
     EXPECT_EQ(p.size(), 1);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_TRUE(p.add("key1", parameter::string("value"sv)));
     EXPECT_STREQ(p[1].key().data(), "key1");
     EXPECT_EQ(p.size(), 2);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_TRUE(p.add("key2", parameter::string("value"sv)));
     EXPECT_STREQ(p[2].key().data(), "key2");
     EXPECT_EQ(p.size(), 3);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_TRUE(p.add("key3", parameter::string("value"sv)));
     EXPECT_STREQ(p[3].key().data(), "key3");
     EXPECT_EQ(p.size(), 4);
+    EXPECT_EQ(p.length(), 0);
 
     auto v = parameter::string("value"sv);
     EXPECT_TRUE(p.add("key4", std::move(v)));
     EXPECT_STREQ(p[4].key().data(), "key4");
     EXPECT_EQ(p.size(), 5);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_FALSE(p.add(parameter::string("value"sv)));
 
     v = parameter::string("value"sv);
     EXPECT_FALSE(p.add(std::move(v)));
 
-    EXPECT_THROW(std::string_view(p).data(), bad_cast);
+    EXPECT_THROW(auto s = std::string(p), bad_cast);
+    EXPECT_THROW(auto sv = std::string_view(p), bad_cast);
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 }
 
 TEST(ParameterTest, Array)
@@ -158,29 +216,88 @@ TEST(ParameterTest, Array)
     parameter p = parameter::array();
     EXPECT_EQ(p.type(), parameter_type::array);
     EXPECT_EQ(p.size(), 0);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_TRUE(p.add(parameter::string("value"sv)));
     EXPECT_EQ(p.size(), 1);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_TRUE(p.add(parameter::string("value"sv)));
     EXPECT_EQ(p.size(), 2);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_TRUE(p.add(parameter::string("value"sv)));
     EXPECT_EQ(p.size(), 3);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_TRUE(p.add(parameter::string("value"sv)));
     EXPECT_EQ(p.size(), 4);
+    EXPECT_EQ(p.length(), 0);
 
     auto v = parameter::string("value"sv);
     EXPECT_TRUE(p.add(std::move(v)));
     EXPECT_EQ(p.size(), 5);
+    EXPECT_EQ(p.length(), 0);
 
     EXPECT_FALSE(p.add("key", parameter::string("value"sv)));
 
     v = parameter::string("value"sv);
     EXPECT_FALSE(p.add("key", std::move(v)));
 
-    EXPECT_THROW(std::string_view(p).data(), bad_cast);
+    EXPECT_THROW(auto s = std::string(p), bad_cast);
+    EXPECT_THROW(auto sv = std::string_view(p), bad_cast);
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 }
+
+TEST(ParameterTest, StaticCastFromMapObject)
+{
+    int size = 40;
+    ddwaf_object obj, tmp;
+    ddwaf_object_map(&obj);
+    for (int i = 0; i < size; i++) {
+        ddwaf_object_map_add(&obj, std::to_string(i).c_str(),
+            ddwaf_object_string(&tmp, "value"));
+    }
+
+    parameter p = static_cast<parameter>(obj);;
+    EXPECT_EQ(p.type(), parameter_type::map);
+    EXPECT_EQ(p.length(), 0);
+    EXPECT_EQ(p.size(), size);
+
+    for (int i = 0; i < size; i++) {
+        EXPECT_TRUE(p[i].is_valid());
+        EXPECT_TRUE(p[i].is_string());
+        EXPECT_STREQ(p[i].key().data(), std::to_string(i).c_str());
+        EXPECT_STREQ(std::string_view(p[i]).data(), "value");
+    }
+
+    EXPECT_THROW(p[size], std::out_of_range);
+}
+
+TEST(ParameterTest, StaticCastFromArrayObject)
+{
+    int size = 40;
+    ddwaf_object obj, tmp;
+    ddwaf_object_array(&obj);
+    for (int i = 0; i < size; i++) {
+        ddwaf_object_array_add(&obj,
+            ddwaf_object_string(&tmp, std::to_string(i).c_str()));
+    }
+
+    parameter p = static_cast<parameter>(obj);
+    EXPECT_EQ(p.type(), parameter_type::array);
+    EXPECT_EQ(p.length(), 0);
+    EXPECT_EQ(p.size(), size);
+
+    for (int i = 0; i < size; i++) {
+        EXPECT_TRUE(p[i].is_valid());
+        EXPECT_TRUE(p[i].is_string());
+        EXPECT_STREQ(std::string_view(p[i]).data(), std::to_string(i).c_str());
+    }
+
+    EXPECT_THROW(p[size], std::out_of_range);
+}
+
 
 } // namespace dds

--- a/tests/helper/parameter_test.cpp
+++ b/tests/helper/parameter_test.cpp
@@ -5,6 +5,7 @@
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 #include "common.hpp"
 #include <parameter.hpp>
+#include <exception.hpp>
 
 const std::string waf_rule =
     R"({"version":"1.0","events":[{"id":1,"tags":{"type":"flow1"},"conditions":[{"operation":"match_regex","parameters":{"inputs":["arg1"],"regex":"^string.*"}},{"operation":"match_regex","parameters":{"inputs":["arg2"],"regex":".*"}}],"action":"record"}]})";
@@ -14,183 +15,172 @@ namespace dds {
 TEST(ParameterTest, EmptyConstructor)
 {
     parameter p;
-    EXPECT_EQ(p.type, DDWAF_OBJ_INVALID);
+    EXPECT_EQ(p.type(), parameter_type::invalid);
     EXPECT_FALSE(p.is_valid());
-    p.free();
 }
 
 TEST(ParameterTest, UintMaxConstructor)
 {
     uint64_t value = std::numeric_limits<uint64_t>::max();
-    parameter p(value);
-    EXPECT_EQ(p.type, DDWAF_OBJ_STRING);
+    parameter p= parameter::uint64(value);
+    EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_FALSE(p[0].is_valid());
+    EXPECT_THROW(p[0], std::out_of_range);
 
     std::stringstream ss;
     ss << value;
     EXPECT_TRUE(p.stringValue == ss.str());
-    p.free();
 }
 
 TEST(ParameterTest, UintMinConstructor)
 {
     uint64_t value = std::numeric_limits<uint64_t>::min();
-    parameter p(value);
-    EXPECT_EQ(p.type, DDWAF_OBJ_STRING);
+    parameter p = parameter::uint64(value);
+    EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_FALSE(p[0].is_valid());
+    EXPECT_THROW(p[0], std::out_of_range);
 
     std::stringstream ss;
     ss << value;
     EXPECT_TRUE(p.stringValue == ss.str());
-    p.free();
 }
 
 TEST(ParameterTest, IntMaxConstructor)
 {
     int64_t value = std::numeric_limits<int64_t>::max();
-    parameter p(value);
-    EXPECT_EQ(p.type, DDWAF_OBJ_STRING);
+    parameter p = parameter::int64(value);
+    EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_FALSE(p[0].is_valid());
+    EXPECT_THROW(p[0], std::out_of_range);
 
     std::stringstream ss;
     ss << value;
     EXPECT_TRUE(p.stringValue == ss.str());
-    p.free();
 }
 
 TEST(ParameterTest, IntMinConstructor)
 {
     int64_t value = std::numeric_limits<int64_t>::min();
-    parameter p(value);
-    EXPECT_EQ(p.type, DDWAF_OBJ_STRING);
+    parameter p = parameter::int64(value);
+    EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_FALSE(p[0].is_valid());
+    EXPECT_THROW(p[0], std::out_of_range);
 
     std::stringstream ss;
     ss << value;
     EXPECT_TRUE(p.stringValue == ss.str());
-    p.free();
 }
 
 TEST(ParameterTest, StringConstructor)
 {
     std::string value("thisisastring");
-    parameter p(value);
-    EXPECT_EQ(p.type, DDWAF_OBJ_STRING);
+    parameter p = parameter::string(value);
+    EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_FALSE(p[0].is_valid());
+    EXPECT_THROW(p[0], std::out_of_range);
 
     EXPECT_TRUE(p.stringValue == value);
-    p.free();
 }
 
 TEST(ParameterTest, StringViewConstructor)
 {
-    parameter p("thisisastring"sv);
-    EXPECT_EQ(p.type, DDWAF_OBJ_STRING);
+    parameter p = parameter::string("thisisastring"sv);
+    EXPECT_EQ(p.type(), parameter_type::string);
     EXPECT_NE(p.stringValue, nullptr);
-    EXPECT_FALSE(p[0].is_valid());
+    EXPECT_THROW(p[0], std::out_of_range);
 
     EXPECT_TRUE(p.stringValue == "thisisastring"sv);
-    p.free();
 }
 
 TEST(ParameterTest, MoveConstructor)
 {
-    parameter p("thisisastring"sv);
+    parameter p = parameter::string("thisisastring"sv);
     parameter pcopy(std::move(p));
 
-    EXPECT_EQ(pcopy.type, DDWAF_OBJ_STRING);
+    EXPECT_EQ(pcopy.type(), parameter_type::string);
     EXPECT_STREQ(pcopy.stringValue, "thisisastring");
 
     EXPECT_FALSE(p.is_valid());
-    pcopy.free();
 }
 
 TEST(ParameterTest, ObjectConstructor)
 {
     ddwaf_object pw{};
-    pw.parameterName = "param";
+    pw.parameterName = strdup("param");
     pw.parameterNameLength = sizeof("param") - 1;
-    pw.stringValue = "stringValue";
-    pw.type = DDWAF_OBJ_STRING;
+    pw.stringValue = strdup("stringValue");
+    pw.ddwaf_object::type = DDWAF_OBJ_STRING;
 
     parameter p(pw);
     EXPECT_EQ(p.parameterName, pw.parameterName);
     EXPECT_EQ(p.parameterNameLength, pw.parameterNameLength);
     EXPECT_EQ(p.stringValue, pw.stringValue);
-    EXPECT_EQ(p.type, pw.type);
-
-    // Freeing would attempt an invalid free on string literals.
+    EXPECT_EQ(p.type(), pw.type);
 }
 
 TEST(ParameterTest, Map)
 {
     parameter p = parameter::map();
-    EXPECT_EQ(p.type, DDWAF_OBJ_MAP);
+    EXPECT_EQ(p.type(), parameter_type::map);
     EXPECT_EQ(p.size(), 0);
 
-    EXPECT_TRUE(p.add("key0", parameter("value"sv)));
+    EXPECT_TRUE(p.add("key0", parameter::string("value"sv)));
     EXPECT_STREQ(p[0].key().data(), "key0");
     EXPECT_EQ(p.size(), 1);
 
-    EXPECT_TRUE(p.add("key1", parameter("value"sv)));
+    EXPECT_TRUE(p.add("key1", parameter::string("value"sv)));
     EXPECT_STREQ(p[1].key().data(), "key1");
     EXPECT_EQ(p.size(), 2);
 
-    EXPECT_TRUE(p.add("key2", parameter("value"sv)));
+    EXPECT_TRUE(p.add("key2", parameter::string("value"sv)));
     EXPECT_STREQ(p[2].key().data(), "key2");
     EXPECT_EQ(p.size(), 3);
 
-    EXPECT_TRUE(p.add("key3", parameter("value"sv)));
+    EXPECT_TRUE(p.add("key3", parameter::string("value"sv)));
     EXPECT_STREQ(p[3].key().data(), "key3");
     EXPECT_EQ(p.size(), 4);
 
-    // const ref test
-    auto v = parameter("value"sv);
-    EXPECT_TRUE(p.add("key4", v));
+    auto v = parameter::string("value"sv);
+    EXPECT_TRUE(p.add("key4", std::move(v)));
     EXPECT_STREQ(p[4].key().data(), "key4");
     EXPECT_EQ(p.size(), 5);
 
-    EXPECT_FALSE(p.add(parameter("value"sv)));
-    EXPECT_FALSE(p.add(v));
+    EXPECT_FALSE(p.add(parameter::string("value"sv)));
 
-    EXPECT_STREQ(std::string_view(p).data(), nullptr);
+    v = parameter::string("value"sv);
+    EXPECT_FALSE(p.add(std::move(v)));
 
-    p.free();
+    EXPECT_THROW(std::string_view(p).data(), bad_cast);
 }
 
 TEST(ParameterTest, Array)
 {
     parameter p = parameter::array();
-    EXPECT_EQ(p.type, DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(p.type(), parameter_type::array);
     EXPECT_EQ(p.size(), 0);
 
-    EXPECT_TRUE(p.add(parameter("value"sv)));
+    EXPECT_TRUE(p.add(parameter::string("value"sv)));
     EXPECT_EQ(p.size(), 1);
 
-    EXPECT_TRUE(p.add(parameter("value"sv)));
+    EXPECT_TRUE(p.add(parameter::string("value"sv)));
     EXPECT_EQ(p.size(), 2);
 
-    EXPECT_TRUE(p.add(parameter("value"sv)));
+    EXPECT_TRUE(p.add(parameter::string("value"sv)));
     EXPECT_EQ(p.size(), 3);
 
-    EXPECT_TRUE(p.add(parameter("value"sv)));
+    EXPECT_TRUE(p.add(parameter::string("value"sv)));
     EXPECT_EQ(p.size(), 4);
 
-    // const ref test
-    auto v = parameter("value"sv);
-    EXPECT_TRUE(p.add(v));
+    auto v = parameter::string("value"sv);
+    EXPECT_TRUE(p.add(std::move(v)));
     EXPECT_EQ(p.size(), 5);
 
-    EXPECT_FALSE(p.add("key", parameter("value"sv)));
-    EXPECT_FALSE(p.add("key", v));
+    EXPECT_FALSE(p.add("key", parameter::string("value"sv)));
 
-    EXPECT_STREQ(std::string_view(p).data(), nullptr);
-    p.free();
+    v = parameter::string("value"sv);
+    EXPECT_FALSE(p.add("key", std::move(v)));
+
+    EXPECT_THROW(std::string_view(p).data(), bad_cast);
 }
 
 } // namespace dds

--- a/tests/helper/parameter_view_test.cpp
+++ b/tests/helper/parameter_view_test.cpp
@@ -1,0 +1,345 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+#include "common.hpp"
+#include <exception.hpp>
+#include <parameter_view.hpp>
+#include <iostream>
+#include <limits>
+
+namespace dds {
+
+TEST(ParameterViewTest, EmptyConstructor)
+{
+    parameter_view p;
+    EXPECT_EQ(p.type(), parameter_type::invalid);
+    EXPECT_FALSE(p.is_valid());
+
+    EXPECT_THROW(auto s = std::string(p), bad_cast);
+    EXPECT_THROW(auto sv = std::string_view(p), bad_cast);
+    EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
+
+    EXPECT_THROW([&]{
+        for (auto value : p) {
+            EXPECT_FALSE(value.is_valid());
+        }} (),
+        invalid_type
+    );
+}
+
+TEST(ParameterViewTest, FromStringParameter)
+{
+    std::string value("thisisastring");
+    parameter p = parameter::string(value);
+
+    parameter_view pv(p);
+    EXPECT_EQ(p.type(), pv.type());
+    EXPECT_EQ(p.length(), pv.length());
+    EXPECT_EQ(p.size(), pv.size());
+
+    EXPECT_NO_THROW(auto s = std::string(pv));
+    EXPECT_NO_THROW(auto sv = std::string_view(pv));
+    EXPECT_THROW(auto u64 = uint64_t(pv), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(pv), bad_cast);
+
+    EXPECT_THROW([&]{
+        for (auto value : pv) {
+            EXPECT_FALSE(value.is_valid());
+        }} (),
+        invalid_type
+    );
+
+    EXPECT_THROW(auto &pv0 = pv[0], invalid_type);
+}
+
+TEST(ParameterViewTest, FromArrayParameter)
+{
+    int i;
+    parameter p = parameter::array();
+    for (i = 0; i < 5; i++) {
+        p.add(parameter::string(std::to_string(i)));
+    }
+
+    parameter_view pv(p);
+    EXPECT_EQ(pv.type(), p.type());
+    EXPECT_EQ(pv.length(), p.length());
+    EXPECT_EQ(pv.size(), p.size());
+
+    i = 0;
+    for (auto value : pv) {
+        EXPECT_TRUE(value.is_valid());
+        EXPECT_TRUE(value.is_string());
+        EXPECT_STREQ(std::string_view(value).data(), std::to_string(i).c_str());
+        i++;
+    }
+
+    for (i = 0; i < 5; i++) {
+        EXPECT_TRUE(pv[i].is_valid());
+        EXPECT_TRUE(pv[i].is_string());
+        EXPECT_STREQ(std::string_view(pv[i]).data(), std::to_string(i).c_str());
+    }
+
+    EXPECT_THROW(pv[i], std::out_of_range);
+}
+
+TEST(ParameterViewTest, FromMapParameter)
+{
+    int i;
+    parameter p = parameter::map();
+    for (i = 0; i < 5; i++) {
+        p.add(std::to_string(i), parameter::string("value"sv));
+    }
+
+    parameter_view pv(p);
+    EXPECT_EQ(pv.type(), p.type());
+    EXPECT_EQ(pv.length(), p.length());
+    EXPECT_EQ(pv.size(), p.size());
+
+    i = 0;
+    for (auto value : pv) {
+        EXPECT_TRUE(value.is_valid());
+        EXPECT_TRUE(value.is_string());
+        EXPECT_STREQ(value.key().data(), std::to_string(i).c_str());
+        EXPECT_STREQ(std::string_view(value).data(), "value");
+        i++;
+    }
+
+    for (i = 0; i < 5; i++) {
+        EXPECT_TRUE(pv[i].is_valid());
+        EXPECT_TRUE(pv[i].is_string());
+        EXPECT_STREQ(pv[i].key().data(), std::to_string(i).c_str());
+        EXPECT_STREQ(std::string_view(pv[i]).data(), "value");
+    }
+
+    EXPECT_THROW(pv[i], std::out_of_range);
+}
+
+TEST(ParameterViewTest, FromStringObject)
+{
+    std::string value("thisisastring");
+    ddwaf_object obj;
+    ddwaf_object_stringl(&obj, value.data(), value.size());
+
+    parameter_view pv(obj);
+    EXPECT_EQ(pv.type(), parameter_type::string);
+    EXPECT_EQ(pv.length(), value.size());
+    EXPECT_EQ(pv.size(), 0);
+
+    EXPECT_NO_THROW(auto s = std::string(pv));
+    EXPECT_NO_THROW(auto sv = std::string_view(pv));
+    EXPECT_THROW(auto u64 = uint64_t(pv), bad_cast);
+    EXPECT_THROW(auto i64 = int64_t(pv), bad_cast);
+
+    EXPECT_THROW([&]{
+        for (auto value : pv) {
+            EXPECT_FALSE(value.is_valid());
+        }} (),
+        invalid_type
+    );
+
+    EXPECT_THROW(auto &pv0 = pv[0], invalid_type);
+    ddwaf_object_free(&obj);
+}
+
+TEST(ParameterViewTest, FromUint64Object)
+{
+    ddwaf_object obj;
+    ddwaf_object_unsigned_force(&obj,
+        std::numeric_limits<uint64_t>::max());
+
+    parameter_view pv(obj);
+    EXPECT_EQ(pv.type(), parameter_type::uint64);
+    EXPECT_EQ(pv.length(), 0);
+    EXPECT_EQ(pv.size(), 0);
+
+    EXPECT_THROW(auto s = std::string(pv), bad_cast);
+    EXPECT_THROW(auto sv = std::string_view(pv), bad_cast);
+    EXPECT_NO_THROW(auto u64 = uint64_t(pv));
+    EXPECT_THROW(auto i64 = int64_t(pv), bad_cast);
+
+    EXPECT_THROW([&]{
+        for (auto value : pv) {
+            EXPECT_FALSE(value.is_valid());
+        }} (),
+        invalid_type
+    );
+
+    EXPECT_THROW(auto &pv0 = pv[0], invalid_type);
+}
+
+TEST(ParameterViewTest, FromInt64Object)
+{
+    ddwaf_object obj;
+    ddwaf_object_signed_force(&obj,
+        std::numeric_limits<int64_t>::min());
+
+    parameter_view pv(obj);
+    EXPECT_EQ(pv.type(), parameter_type::int64);
+    EXPECT_EQ(pv.length(), 0);
+    EXPECT_EQ(pv.size(), 0);
+
+    EXPECT_THROW(auto s = std::string(pv), bad_cast);
+    EXPECT_THROW(auto sv = std::string_view(pv), bad_cast);
+    EXPECT_THROW(auto u64 = uint64_t(pv), bad_cast);
+    EXPECT_NO_THROW(auto i64 = int64_t(pv));
+
+    EXPECT_THROW([&]{
+        for (auto value : pv) {
+            EXPECT_FALSE(value.is_valid());
+        }} (),
+        invalid_type
+    );
+
+    EXPECT_THROW(auto &pv0 = pv[0], invalid_type);
+}
+
+TEST(ParameterViewTest, FromArrayObject)
+{
+    int i;
+    int size = 40;
+    ddwaf_object obj, tmp;
+    ddwaf_object_array(&obj);
+    for (i = 0; i < size; i++) {
+        ddwaf_object_array_add(&obj,
+            ddwaf_object_string(&tmp, std::to_string(i).c_str()));
+    }
+
+    parameter_view pv(obj);
+    EXPECT_EQ(pv.type(), parameter_type::array);
+    EXPECT_EQ(pv.length(), 0);
+    EXPECT_EQ(pv.size(), size);
+
+    i = 0;
+    for (auto value : pv) {
+        EXPECT_TRUE(value.is_valid());
+        EXPECT_TRUE(value.is_string());
+        EXPECT_STREQ(std::string_view(value).data(), std::to_string(i).c_str());
+        i++;
+    }
+
+    for (i = 0; i < size; i++) {
+        EXPECT_TRUE(pv[i].is_valid());
+        EXPECT_TRUE(pv[i].is_string());
+        EXPECT_STREQ(std::string_view(pv[i]).data(), std::to_string(i).c_str());
+    }
+
+    EXPECT_THROW(pv[i], std::out_of_range);
+
+    ddwaf_object_free(&obj);
+}
+
+TEST(ParameterViewTest, FromMapObject)
+{
+    int i;
+    int size = 40;
+    ddwaf_object obj, tmp;
+    ddwaf_object_map(&obj);
+    for (i = 0; i < size; i++) {
+        ddwaf_object_map_add(&obj, std::to_string(i).c_str(),
+            ddwaf_object_string(&tmp, "value"));
+    }
+
+    parameter_view pv(obj);
+    EXPECT_EQ(pv.type(), parameter_type::map);
+    EXPECT_EQ(pv.length(), 0);
+    EXPECT_EQ(pv.size(), size);
+
+    i = 0;
+    for (auto value : pv) {
+        EXPECT_TRUE(value.is_valid());
+        EXPECT_TRUE(value.is_string());
+        EXPECT_STREQ(value.key().data(), std::to_string(i).c_str());
+        EXPECT_STREQ(std::string_view(value).data(), "value");
+        i++;
+    }
+
+    for (i = 0; i < size; i++) {
+        EXPECT_TRUE(pv[i].is_valid());
+        EXPECT_TRUE(pv[i].is_string());
+        EXPECT_STREQ(pv[i].key().data(), std::to_string(i).c_str());
+        EXPECT_STREQ(std::string_view(pv[i]).data(), "value");
+    }
+
+    EXPECT_THROW(pv[i], std::out_of_range);
+
+    ddwaf_object_free(&obj);
+}
+
+TEST(ParameterViewTest, StaticCastFromMapObject)
+{
+    int i;
+    int size = 40;
+    ddwaf_object obj, tmp;
+    ddwaf_object_map(&obj);
+    for (i = 0; i < size; i++) {
+        ddwaf_object_map_add(&obj, std::to_string(i).c_str(),
+            ddwaf_object_string(&tmp, "value"));
+    }
+
+    parameter_view pv = static_cast<parameter_view>(obj);;
+    EXPECT_EQ(pv.type(), parameter_type::map);
+    EXPECT_EQ(pv.length(), 0);
+    EXPECT_EQ(pv.size(), size);
+
+    i = 0;
+    for (auto value : pv) {
+        EXPECT_TRUE(value.is_valid());
+        EXPECT_TRUE(value.is_string());
+        EXPECT_STREQ(value.key().data(), std::to_string(i).c_str());
+        EXPECT_STREQ(std::string_view(value).data(), "value");
+        i++;
+    }
+
+    for (i = 0; i < size; i++) {
+        EXPECT_TRUE(pv[i].is_valid());
+        EXPECT_TRUE(pv[i].is_string());
+        EXPECT_STREQ(pv[i].key().data(), std::to_string(i).c_str());
+        EXPECT_STREQ(std::string_view(pv[i]).data(), "value");
+    }
+
+    EXPECT_THROW(pv[i], std::out_of_range);
+
+    ddwaf_object_free(&obj);
+}
+
+TEST(ParameterViewTest, StaticCastFromArrayObject)
+{
+    int i;
+    int size = 40;
+    ddwaf_object obj, tmp;
+    ddwaf_object_array(&obj);
+    for (i = 0; i < size; i++) {
+        ddwaf_object_array_add(&obj,
+            ddwaf_object_string(&tmp, std::to_string(i).c_str()));
+    }
+
+    parameter_view pv = static_cast<parameter_view>(obj);
+    EXPECT_EQ(pv.type(), parameter_type::array);
+    EXPECT_EQ(pv.length(), 0);
+    EXPECT_EQ(pv.size(), size);
+
+    i = 0;
+    for (auto value : pv) {
+        EXPECT_TRUE(value.is_valid());
+        EXPECT_TRUE(value.is_string());
+        EXPECT_STREQ(std::string_view(value).data(), std::to_string(i).c_str());
+        i++;
+    }
+
+    for (i = 0; i < size; i++) {
+        EXPECT_TRUE(pv[i].is_valid());
+        EXPECT_TRUE(pv[i].is_string());
+        EXPECT_STREQ(std::string_view(pv[i]).data(), std::to_string(i).c_str());
+    }
+
+    EXPECT_THROW(pv[size], std::out_of_range);
+
+    ddwaf_object_free(&obj);
+}
+
+
+
+}

--- a/tests/helper/parameter_view_test.cpp
+++ b/tests/helper/parameter_view_test.cpp
@@ -5,9 +5,9 @@
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 #include "common.hpp"
 #include <exception.hpp>
-#include <parameter_view.hpp>
 #include <iostream>
 #include <limits>
+#include <parameter_view.hpp>
 
 namespace dds {
 
@@ -22,12 +22,11 @@ TEST(ParameterViewTest, EmptyConstructor)
     EXPECT_THROW(auto u64 = uint64_t(p), bad_cast);
     EXPECT_THROW(auto i64 = int64_t(p), bad_cast);
 
-    EXPECT_THROW([&]{
-        for (auto value : p) {
-            EXPECT_FALSE(value.is_valid());
-        }} (),
-        invalid_type
-    );
+    EXPECT_THROW(
+        [&] {
+            for (auto value : p) { EXPECT_FALSE(value.is_valid()); }
+        }(),
+        invalid_type);
 }
 
 TEST(ParameterViewTest, FromStringParameter)
@@ -45,12 +44,11 @@ TEST(ParameterViewTest, FromStringParameter)
     EXPECT_THROW(auto u64 = uint64_t(pv), bad_cast);
     EXPECT_THROW(auto i64 = int64_t(pv), bad_cast);
 
-    EXPECT_THROW([&]{
-        for (auto value : pv) {
-            EXPECT_FALSE(value.is_valid());
-        }} (),
-        invalid_type
-    );
+    EXPECT_THROW(
+        [&] {
+            for (auto value : pv) { EXPECT_FALSE(value.is_valid()); }
+        }(),
+        invalid_type);
 
     EXPECT_THROW(auto &pv0 = pv[0], invalid_type);
 }
@@ -59,9 +57,7 @@ TEST(ParameterViewTest, FromArrayParameter)
 {
     int i;
     parameter p = parameter::array();
-    for (i = 0; i < 5; i++) {
-        p.add(parameter::string(std::to_string(i)));
-    }
+    for (i = 0; i < 5; i++) { p.add(parameter::string(std::to_string(i))); }
 
     parameter_view pv(p);
     EXPECT_EQ(pv.type(), p.type());
@@ -133,12 +129,11 @@ TEST(ParameterViewTest, FromStringObject)
     EXPECT_THROW(auto u64 = uint64_t(pv), bad_cast);
     EXPECT_THROW(auto i64 = int64_t(pv), bad_cast);
 
-    EXPECT_THROW([&]{
-        for (auto value : pv) {
-            EXPECT_FALSE(value.is_valid());
-        }} (),
-        invalid_type
-    );
+    EXPECT_THROW(
+        [&] {
+            for (auto value : pv) { EXPECT_FALSE(value.is_valid()); }
+        }(),
+        invalid_type);
 
     EXPECT_THROW(auto &pv0 = pv[0], invalid_type);
     ddwaf_object_free(&obj);
@@ -147,8 +142,7 @@ TEST(ParameterViewTest, FromStringObject)
 TEST(ParameterViewTest, FromUint64Object)
 {
     ddwaf_object obj;
-    ddwaf_object_unsigned_force(&obj,
-        std::numeric_limits<uint64_t>::max());
+    ddwaf_object_unsigned_force(&obj, std::numeric_limits<uint64_t>::max());
 
     parameter_view pv(obj);
     EXPECT_EQ(pv.type(), parameter_type::uint64);
@@ -160,12 +154,11 @@ TEST(ParameterViewTest, FromUint64Object)
     EXPECT_NO_THROW(auto u64 = uint64_t(pv));
     EXPECT_THROW(auto i64 = int64_t(pv), bad_cast);
 
-    EXPECT_THROW([&]{
-        for (auto value : pv) {
-            EXPECT_FALSE(value.is_valid());
-        }} (),
-        invalid_type
-    );
+    EXPECT_THROW(
+        [&] {
+            for (auto value : pv) { EXPECT_FALSE(value.is_valid()); }
+        }(),
+        invalid_type);
 
     EXPECT_THROW(auto &pv0 = pv[0], invalid_type);
 }
@@ -173,8 +166,7 @@ TEST(ParameterViewTest, FromUint64Object)
 TEST(ParameterViewTest, FromInt64Object)
 {
     ddwaf_object obj;
-    ddwaf_object_signed_force(&obj,
-        std::numeric_limits<int64_t>::min());
+    ddwaf_object_signed_force(&obj, std::numeric_limits<int64_t>::min());
 
     parameter_view pv(obj);
     EXPECT_EQ(pv.type(), parameter_type::int64);
@@ -186,12 +178,11 @@ TEST(ParameterViewTest, FromInt64Object)
     EXPECT_THROW(auto u64 = uint64_t(pv), bad_cast);
     EXPECT_NO_THROW(auto i64 = int64_t(pv));
 
-    EXPECT_THROW([&]{
-        for (auto value : pv) {
-            EXPECT_FALSE(value.is_valid());
-        }} (),
-        invalid_type
-    );
+    EXPECT_THROW(
+        [&] {
+            for (auto value : pv) { EXPECT_FALSE(value.is_valid()); }
+        }(),
+        invalid_type);
 
     EXPECT_THROW(auto &pv0 = pv[0], invalid_type);
 }
@@ -203,8 +194,8 @@ TEST(ParameterViewTest, FromArrayObject)
     ddwaf_object obj, tmp;
     ddwaf_object_array(&obj);
     for (i = 0; i < size; i++) {
-        ddwaf_object_array_add(&obj,
-            ddwaf_object_string(&tmp, std::to_string(i).c_str()));
+        ddwaf_object_array_add(
+            &obj, ddwaf_object_string(&tmp, std::to_string(i).c_str()));
     }
 
     parameter_view pv(obj);
@@ -279,7 +270,8 @@ TEST(ParameterViewTest, StaticCastFromMapObject)
             ddwaf_object_string(&tmp, "value"));
     }
 
-    parameter_view pv = static_cast<parameter_view>(obj);;
+    parameter_view pv = static_cast<parameter_view>(obj);
+    ;
     EXPECT_EQ(pv.type(), parameter_type::map);
     EXPECT_EQ(pv.length(), 0);
     EXPECT_EQ(pv.size(), size);
@@ -312,8 +304,8 @@ TEST(ParameterViewTest, StaticCastFromArrayObject)
     ddwaf_object obj, tmp;
     ddwaf_object_array(&obj);
     for (i = 0; i < size; i++) {
-        ddwaf_object_array_add(&obj,
-            ddwaf_object_string(&tmp, std::to_string(i).c_str()));
+        ddwaf_object_array_add(
+            &obj, ddwaf_object_string(&tmp, std::to_string(i).c_str()));
     }
 
     parameter_view pv = static_cast<parameter_view>(obj);
@@ -340,6 +332,4 @@ TEST(ParameterViewTest, StaticCastFromArrayObject)
     ddwaf_object_free(&obj);
 }
 
-
-
-}
+} // namespace dds

--- a/tests/helper/waf_test.cpp
+++ b/tests/helper/waf_test.cpp
@@ -36,8 +36,7 @@ using log_counter_sink_st = log_counter_sink<spdlog::details::null_mutex>;
 
 TEST(WafTest, RunWithInvalidParam)
 {
-    subscriber::ptr wi{waf::instance::from_string(
-        waf_rule, client_settings::default_waf_timeout_us)};
+    subscriber::ptr wi{waf::instance::from_string(waf_rule)};
     auto ctx = wi->get_listener();
     parameter_view pv;
     EXPECT_THROW(ctx->call(pv), invalid_object);
@@ -58,8 +57,7 @@ TEST(WafTest, RunWithTimeout)
 
 TEST(WafTest, ValidRunGood)
 {
-    subscriber::ptr wi{waf::instance::from_string(
-        waf_rule, client_settings::default_waf_timeout_us)};
+    subscriber::ptr wi{waf::instance::from_string(waf_rule)};
     auto ctx = wi->get_listener();
 
     auto p = parameter::map();
@@ -72,8 +70,7 @@ TEST(WafTest, ValidRunGood)
 
 TEST(WafTest, ValidRunMonitor)
 {
-    subscriber::ptr wi{waf::instance::from_string(
-        waf_rule, client_settings::default_waf_timeout_us)};
+    subscriber::ptr wi{waf::instance::from_string(waf_rule)};
     auto ctx = wi->get_listener();
 
     auto p = parameter::map();

--- a/tests/helper/waf_test.cpp
+++ b/tests/helper/waf_test.cpp
@@ -39,9 +39,8 @@ TEST(WafTest, RunWithInvalidParam)
     subscriber::ptr wi{waf::instance::from_string(
         waf_rule, client_settings::default_waf_timeout_us)};
     auto ctx = wi->get_listener();
-    parameter p;
-    EXPECT_THROW(ctx->call(p), invalid_object);
-    p.free();
+    parameter_view pv;
+    EXPECT_THROW(ctx->call(pv), invalid_object);
 }
 
 TEST(WafTest, RunWithTimeout)
@@ -50,11 +49,11 @@ TEST(WafTest, RunWithTimeout)
     auto ctx = wi->get_listener();
 
     auto p = parameter::map();
-    p.add("arg1", parameter("string 1"sv));
-    p.add("arg2", parameter("string 2"sv));
+    p.add("arg1", parameter::string("string 1"sv));
+    p.add("arg2", parameter::string("string 2"sv));
 
-    EXPECT_THROW(ctx->call(p), timeout_error);
-    p.free();
+    parameter_view pv(p);
+    EXPECT_THROW(ctx->call(pv), timeout_error);
 }
 
 TEST(WafTest, ValidRunGood)
@@ -64,10 +63,10 @@ TEST(WafTest, ValidRunGood)
     auto ctx = wi->get_listener();
 
     auto p = parameter::map();
-    p.add("arg1", parameter("string 1"sv));
+    p.add("arg1", parameter::string("string 1"sv));
 
-    auto res = ctx->call(p);
-    p.free();
+    parameter_view pv(p);
+    auto res = ctx->call(pv);
     EXPECT_EQ(res.value, dds::result::code::ok);
 }
 
@@ -78,11 +77,11 @@ TEST(WafTest, ValidRunMonitor)
     auto ctx = wi->get_listener();
 
     auto p = parameter::map();
-    p.add("arg1", parameter("string 1"sv));
-    p.add("arg2", parameter("string 3"sv));
+    p.add("arg1", parameter::string("string 1"sv));
+    p.add("arg2", parameter::string("string 3"sv));
 
-    auto res = ctx->call(p);
-    p.free();
+    parameter_view pv(p);
+    auto res = ctx->call(pv);
     EXPECT_EQ(res.value, dds::result::code::record);
 
     for (auto &match : res.data) {

--- a/tests/helper/worker_pool_test.cpp
+++ b/tests/helper/worker_pool_test.cpp
@@ -7,7 +7,7 @@
 #include <worker_pool.hpp>
 
 namespace {
-void thread_handler(dds::worker::queue_consumer &&wm, bool &running,
+void thread_handler(dds::worker::queue_consumer &wm, bool &running,
     std::mutex &m, std::condition_variable &cv)
 {
     ASSERT_TRUE(wm.running());
@@ -43,8 +43,8 @@ TEST(WorkerPoolTest, LaunchOneWorker)
     std::mutex m;
     std::condition_variable cv;
     bool running = false;
-    wp.launch([&](dds::worker::queue_consumer &&wm) {
-        thread_handler(std::move(wm), running, m, cv);
+    wp.launch([&](dds::worker::queue_consumer &wm) {
+        thread_handler(wm, running, m, cv);
     });
 
     {
@@ -67,8 +67,8 @@ TEST(WorkerPoolTest, LaunchNWorkers)
     bool running = false;
 
     for (int i = 0; i < 10; i++) {
-        wp.launch([&](dds::worker::queue_consumer &&wm) {
-            thread_handler(std::move(wm), running, m, cv);
+        wp.launch([&](dds::worker::queue_consumer &wm) {
+            thread_handler(wm, running, m, cv);
         });
 
         {

--- a/tests/helper/worker_pool_test.cpp
+++ b/tests/helper/worker_pool_test.cpp
@@ -7,7 +7,7 @@
 #include <worker_pool.hpp>
 
 namespace {
-void thread_handler(dds::worker::queue_consumer &wm, bool &running,
+void thread_handler(dds::worker::queue_consumer &&wm, bool &running,
     std::mutex &m, std::condition_variable &cv)
 {
     ASSERT_TRUE(wm.running());
@@ -43,8 +43,8 @@ TEST(WorkerPoolTest, LaunchOneWorker)
     std::mutex m;
     std::condition_variable cv;
     bool running = false;
-    wp.launch([&](dds::worker::queue_consumer &wm) {
-        thread_handler(wm, running, m, cv);
+    wp.launch([&](dds::worker::queue_consumer &&wm) {
+        thread_handler(std::move(wm), running, m, cv);
     });
 
     {
@@ -67,8 +67,8 @@ TEST(WorkerPoolTest, LaunchNWorkers)
     bool running = false;
 
     for (int i = 0; i < 10; i++) {
-        wp.launch([&](dds::worker::queue_consumer &wm) {
-            thread_handler(wm, running, m, cv);
+        wp.launch([&](dds::worker::queue_consumer &&wm) {
+            thread_handler(std::move(wm), running, m, cv);
         });
 
         {


### PR DESCRIPTION
### Description

The implementation of dds::parameter does not necessarily assume ownership of the memory associated with the parameter and still requires manually freeing the relevant memory at the relevant stage.

To ensure that parameter has full ownership of the memory and ensure this is freed on destruction (therefore ensuring RAII), this PR introduces `parameter_view` which is similar to `string_view` in that it assumes no ownership of the memory, but rather provides a "const" access to it while the original parameter can still retain ownership without creating copies.

#### Future work

- Reconcile `parameter_view` with `ddwaf::parameter`
- Potentially avoid `static_cast` from `ddwaf_object` to `parameter` or `parameter_view`, as it's UB, but the compiler provides the expected behaviour. `dynamic_cast` is not an option as `ddwaf_object` is not polymorphic and adding a virtual function to it only for C++ changes its layout. Composition is another alternative which would be suitable for `parameter_view`, but not for `parameter`, unless we store a reference, which is also tricky due to reference invalidation in containers.

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


