### PR TITLE
Enable IP resolution from headers

### DIFF
--- a/src/extension/tags.c
+++ b/src/extension/tags.c
@@ -492,7 +492,7 @@ static void _dd_actor_ip(zend_array *meta_ht, zval *_server)
         return;
     }
 
-    _add_new_zstr_to_meta(meta_ht, _dd_tag_actor_ip_zstr, actor_ip_zstr, true);
+    _add_new_zstr_to_meta(meta_ht, _dd_tag_actor_ip_zstr, actor_ip_zstr, false);
 }
 
 static void _dd_request_headers(zend_array *meta_ht, zval *_server)

--- a/src/extension/tags.c
+++ b/src/extension/tags.c
@@ -6,6 +6,7 @@
 #include "tags.h"
 #include "ddappsec.h"
 #include "ddtrace.h"
+#include "ip_extraction.h"
 #include "logging.h"
 #include "php_compat.h"
 #include "php_helpers.h"
@@ -22,6 +23,7 @@
 #define DD_TAG_HTTP_STATUS_CODE "http.status_code"
 #define DD_TAG_HTTP_URL "http.url"
 #define DD_TAG_NETWORK_CLIENT_IP "network.client.ip"
+#define DD_TAG_ACTOR_IP "actor.ip"
 #define DD_PREFIX_TAG_REQUEST_HEADER "http.request.headers."
 #define DD_TAG_HTTP_RH_CONTENT_LENGTH "http.response.headers.content-length"
 #define DD_TAG_HTTP_RH_CONTENT_TYPE "http.response.headers.content-type"
@@ -38,6 +40,7 @@ static zend_string *_dd_tag_http_user_agent_zstr;
 static zend_string *_dd_tag_http_status_code_zstr;
 static zend_string *_dd_tag_http_url_zstr;
 static zend_string *_dd_tag_network_client_ip_zstr;
+static zend_string *_dd_tag_actor_ip_zstr;
 static zend_string *_dd_tag_rh_content_length;   // response
 static zend_string *_dd_tag_rh_content_type;     // response
 static zend_string *_dd_tag_rh_content_encoding; // response
@@ -84,6 +87,8 @@ void dd_tags_startup()
         zend_string_init_interned(LSTRARG(DD_TAG_HTTP_URL), 1);
     _dd_tag_network_client_ip_zstr =
         zend_string_init_interned(LSTRARG(DD_TAG_NETWORK_CLIENT_IP), 1);
+    _dd_tag_actor_ip_zstr =
+        zend_string_init_interned(LSTRARG(DD_TAG_ACTOR_IP), 1);
 
     _dd_tag_rh_content_length =
         zend_string_init_interned(LSTRARG(DD_TAG_HTTP_RH_CONTENT_LENGTH), 1);
@@ -315,6 +320,7 @@ static void _dd_http_url(zend_array *meta_ht, zval *_server);
 static void _dd_http_user_agent(zend_array *meta_ht, zval *_server);
 static void _dd_http_status_code(zend_array *meta_ht);
 static void _dd_http_network_client_ip(zend_array *meta_ht, zval *_server);
+static void _dd_actor_ip(zend_array *meta_ht, zval *_server);
 static void _dd_request_headers(zend_array *meta_ht, zval *_server);
 static void _dd_response_headers(zend_array *meta_ht);
 
@@ -343,6 +349,7 @@ static void _add_all_tags_to_meta(zval *nonnull meta)
     _dd_http_user_agent(meta_ht, _server);
     _dd_http_status_code(meta_ht);
     _dd_http_network_client_ip(meta_ht, _server);
+    _dd_actor_ip(meta_ht, _server);
     _dd_request_headers(meta_ht, _server);
     _dd_response_headers(meta_ht);
 }
@@ -473,6 +480,19 @@ static void _dd_http_network_client_ip(zend_array *meta_ht, zval *_server)
 
     _add_new_zstr_to_meta(
         meta_ht, _dd_tag_network_client_ip_zstr, remote_addr_zstr, true);
+}
+
+static void _dd_actor_ip(zend_array *meta_ht, zval *_server)
+{
+    if (zend_hash_exists(meta_ht, _dd_tag_actor_ip_zstr)) {
+        return;
+    }
+    zend_string *actor_ip_zstr = dd_ip_extraction_find(_server);
+    if (!actor_ip_zstr) {
+        return;
+    }
+
+    _add_new_zstr_to_meta(meta_ht, _dd_tag_actor_ip_zstr, actor_ip_zstr, true);
 }
 
 static void _dd_request_headers(zend_array *meta_ht, zval *_server)

--- a/tests/extension/ancillary_tags.phpt
+++ b/tests/extension/ancillary_tags.phpt
@@ -58,6 +58,7 @@ print_r($arr);
 --EXPECTF--
 Array
 (
+    [actor.ip] => 7.7.7.7
     [http.method] => GET
     [http.request.headers.accept] => */*
     [http.request.headers.accept-encoding] => gzip

--- a/tests/extension/ancillary_tags_no_replace.phpt
+++ b/tests/extension/ancillary_tags_no_replace.phpt
@@ -30,6 +30,7 @@ $arr = array(
     'http.status_code' => '405',
     'http.response.headers.content-type' => 'text/xml',
     'network.client.ip' => '2.2.2.2',
+    'actor.ip' => '5.5.5.5'
 );
 add_ancillary_tags($arr);
 ksort($arr);
@@ -39,6 +40,7 @@ print_r($arr);
 --EXPECTF--
 Array
 (
+    [actor.ip] => 5.5.5.5
     [http.method] => POST
     [http.request.headers.user-agent] => my user agent
     [http.request.headers.x-forwarded-for] => 8.8.8.8


### PR DESCRIPTION
### Description

IP resolution through headers was available but not being used, this PR starts using it to introduce `actor.ip` to the span.

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


