### PR TITLE
Accept list on x-cluster-client-ip header

### DIFF
--- a/src/extension/ip_extraction.c
+++ b/src/extension/ip_extraction.c
@@ -162,7 +162,7 @@ zend_string *nullable dd_ip_extraction_find(zval *nonnull server)
         return res;
     }
 
-    res = _try_extract(server, _x_cluster_client_ip_key, &_parse_plain);
+    res = _try_extract(server, _x_cluster_client_ip_key, &_parse_x_forwarded_for);
     if (res) {
         return res;
     }

--- a/src/extension/ip_extraction.c
+++ b/src/extension/ip_extraction.c
@@ -162,7 +162,8 @@ zend_string *nullable dd_ip_extraction_find(zval *nonnull server)
         return res;
     }
 
-    res = _try_extract(server, _x_cluster_client_ip_key, &_parse_x_forwarded_for);
+    res =
+        _try_extract(server, _x_cluster_client_ip_key, &_parse_x_forwarded_for);
     if (res) {
         return res;
     }

--- a/src/extension/ip_extraction.h
+++ b/src/extension/ip_extraction.h
@@ -11,8 +11,7 @@
 
 void dd_ip_extraction_startup(void);
 
-// currently unused; we'll need it once we have local blocking
-// since the headers looked at can in principle be forged, it's very much
+// Since the headers looked at can in principle be forged, it's very much
 // recommended that a datadog.appsec.ipheader is set to a header that the server
 // guarantees cannot be forged
 zend_string *nullable dd_ip_extraction_find(zval *nonnull server);

--- a/tests/extension/extract_ip_addr.phpt
+++ b/tests/extension/extract_ip_addr.phpt
@@ -41,6 +41,11 @@ test('x_forwarded', 'far="8.8.8.8",for=4.4.4.4;');
 test('x_forwarded', '   for=127.0.0.1,for= for=,for=;"for = for="" ,; for=8.8.8.8;');
 
 test('x_cluster_client_ip', '2.2.2.2');
+test('x_cluster_client_ip', '127.0.0.1, 2.2.2.2');
+test('x_cluster_client_ip', '10.20.30.40,,');
+test('x_cluster_client_ip', '2001::1');
+test('x_cluster_client_ip', '::1, febf::1, fc00::1, fd00::1,2001:0000::1');
+test('x_cluster_client_ip', '172.16.0.1');
 
 test('forwarded_for', '::1, 127.0.0.1, 2001::1');
 
@@ -139,6 +144,21 @@ string(7) "8.8.8.8"
 
 x_cluster_client_ip: 2.2.2.2
 string(7) "2.2.2.2"
+
+x_cluster_client_ip: 127.0.0.1, 2.2.2.2
+string(7) "2.2.2.2"
+
+x_cluster_client_ip: 10.20.30.40,,
+NULL
+
+x_cluster_client_ip: 2001::1
+string(7) "2001::1"
+
+x_cluster_client_ip: ::1, febf::1, fc00::1, fd00::1,2001:0000::1
+string(7) "2001::1"
+
+x_cluster_client_ip: 172.16.0.1
+NULL
 
 forwarded_for: ::1, 127.0.0.1, 2001::1
 string(7) "2001::1"


### PR DESCRIPTION
### Description

Accept a list instead of a single IP when receiving the header `X-Cluster-Client-IP`.

### Motivation

Primarily compliance with system tests as this header is non-standard.

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass
- [x] If known, an appropriate milestone has been selected
- [x] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


