### PR TITLE
Add obfuscator strings when initialising WAF from settings

### DIFF
--- a/src/helper/subscriber/waf.cpp
+++ b/src/helper/subscriber/waf.cpp
@@ -356,7 +356,8 @@ instance::ptr instance::from_settings(const client_settings &settings,
 {
     dds::parameter param = parse_file(settings.rules_file_or_default());
     return std::make_shared<instance>(
-        param, meta, metrics, settings.waf_timeout_us);
+        param, meta, metrics, settings.waf_timeout_us,
+        settings.obfuscator_key_regex, settings.obfuscator_value_regex);
 }
 
 instance::ptr instance::from_string(std::string_view rule,


### PR DESCRIPTION
### Description

Add obfuscator strings when initialising WAF from settings.

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass
- [x] If known, an appropriate milestone has been selected
- [x] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


