### PR TITLE
Add module order test with / without opcache

### DIFF
--- a/tests/extension/module_order_opcache.phpt
+++ b/tests/extension/module_order_opcache.phpt
@@ -1,7 +1,14 @@
 --TEST--
-Verify ddappsec is always in the module registry after ddtrace
+Verify ddappsec is always in the module registry after ddtrace when opcache is present
+--SKIPIF--
+<?php
+if (!extension_loaded('Zend OPcache')) {
+    die('skip requires opcache');
+}
+?>
 --INI--
 extension=ddtrace.so
+zend_extension=opcache.so
 --FILE--
 <?php
 foreach (get_loaded_extensions() as &$ext) {


### PR DESCRIPTION
### Description

Split module order test to verify the order is correct with or without opcache.

### Motivation

Allows us to skip the test when opcache is not available but still verify the order.
### Additional Notes


