### PR TITLE
Replace `php_error_docref` with `php_log_err`

### DIFF
--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -173,14 +173,8 @@ static PHP_MINIT_FUNCTION(ddappsec)
 
     zend_module_entry *mod_ptr = zend_hash_str_find_ptr(&module_registry,
         PHP_DDAPPSEC_EXTNAME, sizeof(PHP_DDAPPSEC_EXTNAME) - 1);
-    if (mod_ptr == NULL) {
-        mlog(dd_log_error, "Failed to find  ddappsec module in registery. Bug");
-        zend_register_extension(
-            &ddappsec_extension_entry, ddappsec_module_entry.handle);
-    } else {
-        zend_register_extension(&ddappsec_extension_entry, mod_ptr->handle);
-        mod_ptr->handle = NULL;
-    }
+    zend_register_extension(&ddappsec_extension_entry, mod_ptr->handle);
+    mod_ptr->handle = NULL;
 
     dd_phpobj_startup(module_number);
     _register_ini_entries(); // depends on dd_phpobj_startup

--- a/src/extension/logging.c
+++ b/src/extension/logging.c
@@ -522,7 +522,7 @@ static PHP_FUNCTION(datadog_appsec_testing_mlog)
         RETURN_FALSE;
     }
     if (str->len > INT_MAX) {
-        _dd_log_errf(NULL, E_WARNING, "String is too long");
+        _dd_log_errf("String is too long");
         RETURN_FALSE;
     }
 

--- a/src/extension/logging.c
+++ b/src/extension/logging.c
@@ -78,6 +78,19 @@ static const dd_ini_setting ini_settings[] = {
 };
 // clang-format on
 
+static void _dd_log_errf(const char *format, ...)
+{
+    va_list args;
+    char *buffer;
+
+    va_start(args, format);
+    vspprintf(&buffer, 0, format, args);
+    php_log_err(buffer);
+
+    efree(buffer);
+    va_end(args);
+}
+
 void dd_log_startup()
 {
 #ifdef ZTS
@@ -487,8 +500,7 @@ static ZEND_INI_MH(_on_update_log_file)
         return FAILURE;
     }
     if (_log_strategy != log_use_nothing && ZSTR_VAL(new_value) != _log_file) {
-        php_error_docref(
-            NULL, E_WARNING, "Cannot change datadog.appsec.log_file anymore");
+        _dd_log_errf("Cannot change datadog.appsec.log_file anymore");
         return FAILURE; // change not possible already
     }
 
@@ -506,12 +518,11 @@ static PHP_FUNCTION(datadog_appsec_testing_mlog)
     }
 
     if (level < dd_log_off || level > dd_log_trace) {
-        php_error_docref(
-            NULL, E_WARNING, "Level %lld is out of range", (long long)level);
+        _dd_log_errf("Level %lld is out of range", (long long)level);
         RETURN_FALSE;
     }
     if (str->len > INT_MAX) {
-        php_error_docref(NULL, E_WARNING, "String is too long");
+        _dd_log_errf(NULL, E_WARNING, "String is too long");
         RETURN_FALSE;
     }
 


### PR DESCRIPTION
### Description

On PHP versions <= 7.2 `php_error_docref` in ZTS occasionally causes the process to crash due to `zend_get_compiled_filename` returning an invalid value. In this PR we are replacing `php_error_docref` with `php_log_err` in order to continue providing an error message while potentially avoiding the invalid memory access and subsequent crash.

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


