### PR TITLE
Set env values at rinit

### DIFF
--- a/examples/webroot/poolenv.php
+++ b/examples/webroot/poolenv.php
@@ -1,0 +1,3 @@
+<?php
+
+echo sprintf("Value of pool env is %s", ini_get("datadog.appsec.waf_timeout"));

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -11,7 +11,6 @@
 // for open(2)
 #include <dlfcn.h>
 #include <fcntl.h>
-#include <pthread.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -216,14 +215,16 @@ static void _dd_rinit_once(void)
         dd_phpobj_load_env_values();
     }
 }
-static pthread_once_t dd_rinit_once_control = PTHREAD_ONCE_INIT;
+static bool dd_rinit_once_done;
 #endif
 
 static PHP_RINIT_FUNCTION(ddappsec)
 {
 #ifndef ZTS
-    // Things that should only run on the first RINIT
-    pthread_once(&dd_rinit_once_control, _dd_rinit_once);
+    if (!dd_rinit_once_done) {
+        _dd_rinit_once();
+        dd_rinit_once_done = true;
+    }
 #endif
 
     if (!DDAPPSEC_G(enabled)) {

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -11,6 +11,7 @@
 // for open(2)
 #include <dlfcn.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -208,8 +209,17 @@ static PHP_MSHUTDOWN_FUNCTION(ddappsec)
     return SUCCESS;
 }
 
+static void dd_rinit_once(void) {
+    dd_phpobj_load_env_values();
+}
+
+static pthread_once_t dd_rinit_once_control = PTHREAD_ONCE_INIT;
+
 static PHP_RINIT_FUNCTION(ddappsec)
 {
+    // Things that should only run on the first RINIT
+    pthread_once(&dd_rinit_once_control, dd_rinit_once);
+
     if (!DDAPPSEC_G(enabled)) {
         mlog_g(dd_log_debug, "Appsec disabled");
         return SUCCESS;

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -216,7 +216,7 @@ static pthread_once_t dd_rinit_once_control = PTHREAD_ONCE_INIT;
 static PHP_RINIT_FUNCTION(ddappsec)
 {
     // Things that should only run on the first RINIT
-    pthread_once(&dd_rinit_once_control, dd_rinit_once);
+    pthread_once(&dd_rinit_once_control, _dd_rinit_once);
 
     if (!DDAPPSEC_G(enabled)) {
         mlog_g(dd_log_debug, "Appsec disabled");

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -209,14 +209,17 @@ static PHP_MSHUTDOWN_FUNCTION(ddappsec)
     return SUCCESS;
 }
 
+#ifndef ZTS
 static void _dd_rinit_once(void) { dd_phpobj_load_env_values(); }
-
 static pthread_once_t dd_rinit_once_control = PTHREAD_ONCE_INIT;
+#endif
 
 static PHP_RINIT_FUNCTION(ddappsec)
 {
+#ifndef ZTS
     // Things that should only run on the first RINIT
     pthread_once(&dd_rinit_once_control, _dd_rinit_once);
+#endif
 
     if (!DDAPPSEC_G(enabled)) {
         mlog_g(dd_log_debug, "Appsec disabled");

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -209,9 +209,7 @@ static PHP_MSHUTDOWN_FUNCTION(ddappsec)
     return SUCCESS;
 }
 
-static void dd_rinit_once(void) {
-    dd_phpobj_load_env_values();
-}
+static void dd_rinit_once(void) { dd_phpobj_load_env_values(); }
 
 static pthread_once_t dd_rinit_once_control = PTHREAD_ONCE_INIT;
 

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -209,7 +209,7 @@ static PHP_MSHUTDOWN_FUNCTION(ddappsec)
     return SUCCESS;
 }
 
-static void dd_rinit_once(void) { dd_phpobj_load_env_values(); }
+static void _dd_rinit_once(void) { dd_phpobj_load_env_values(); }
 
 static pthread_once_t dd_rinit_once_control = PTHREAD_ONCE_INIT;
 

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -210,7 +210,12 @@ static PHP_MSHUTDOWN_FUNCTION(ddappsec)
 }
 
 #ifndef ZTS
-static void _dd_rinit_once(void) { dd_phpobj_load_env_values(); }
+static void _dd_rinit_once(void)
+{
+    if (strcmp(sapi_module.name, "fpm-fcgi") == 0) {
+        dd_phpobj_load_env_values();
+    }
+}
 static pthread_once_t dd_rinit_once_control = PTHREAD_ONCE_INIT;
 #endif
 

--- a/src/extension/php_objects.c
+++ b/src/extension/php_objects.c
@@ -17,6 +17,7 @@ static zend_llist _function_entry_arrays;
 
 static void _unregister_functions(void *zfe_arr_vp);
 
+#ifndef ZTS
 typedef struct _dd_registered_entries {
     char *nullable name;
     size_t name_len;
@@ -26,6 +27,7 @@ typedef struct _dd_registered_entries {
 #define DD_MAX_REGISTERED_ENTRIES 160
 static uint8_t registered_entries_count = 0;
 static dd_registered_entries registered_entries[DD_MAX_REGISTERED_ENTRIES];
+#endif
 
 void dd_phpobj_startup(int module_number)
 {
@@ -116,11 +118,13 @@ void dd_phpobj_reg_ini_env(const dd_ini_setting *sett)
 
     if (dd_phpobj_reg_ini(defs) == dd_success &&
         registered_entries_count < DD_MAX_REGISTERED_ENTRIES) {
+#ifndef ZTS
         registered_entries[registered_entries_count].name = name;
         registered_entries[registered_entries_count].name_len =
             (size_t)name_len;
         registered_entries[registered_entries_count].env_name = env_name;
         registered_entries_count++;
+#endif
     } else {
         if (name) {
             pefree(name, 1);
@@ -152,9 +156,6 @@ static char *nullable _get_env_name_from_ini_name(
 
     size_t env_name_len = ENV_NAME_PREFIX_LEN + name_len;
     char *env_name = pemalloc(env_name_len + 1, 1);
-    if (!env_name) {
-        return NULL;
-    }
     memcpy(env_name, ENV_NAME_PREFIX, ENV_NAME_PREFIX_LEN);
 
     const char *r = name;
@@ -172,6 +173,7 @@ static char *nullable _get_env_name_from_ini_name(
     return env_name;
 }
 
+#ifndef ZTS
 /**
  * This function is based on fpm_php_zend_ini_alter_master
  * from php-src
@@ -238,6 +240,7 @@ dd_result dd_phpobj_load_env_values()
     }
     return dd_success;
 }
+#endif
 
 static zend_string *nullable _fetch_from_env(const char *nullable env_name)
 {

--- a/src/extension/php_objects.c
+++ b/src/extension/php_objects.c
@@ -19,6 +19,7 @@ static void _unregister_functions(void *zfe_arr_vp);
 
 typedef struct _dd_registered_entries {
     char *nullable name;
+    size_t name_len;
     char *nullable env_name;
 } dd_registered_entries;
 
@@ -116,6 +117,8 @@ void dd_phpobj_reg_ini_env(const dd_ini_setting *sett)
     if (dd_phpobj_reg_ini(defs) == dd_success &&
         registered_entries_count < DD_MAX_REGISTERED_ENTRIES) {
         registered_entries[registered_entries_count].name = name;
+        registered_entries[registered_entries_count].name_len =
+            (size_t)name_len;
         registered_entries[registered_entries_count].env_name = env_name;
         registered_entries_count++;
     } else {
@@ -219,9 +222,8 @@ dd_result dd_phpobj_load_env_values()
         current = registered_entries[--registered_entries_count];
         env_def = _fetch_from_env(current.env_name);
         if (env_def) {
-            _custom_php_zend_ini_alter_master(current.name,
-                strlen(current.name), env_def, PHP_INI_SYSTEM,
-                PHP_INI_STAGE_RUNTIME, true);
+            _custom_php_zend_ini_alter_master(current.name, current.name_len,
+                env_def, PHP_INI_SYSTEM, PHP_INI_STAGE_RUNTIME, true);
             zend_string_efree(env_def); // NOLINT
             env_def = NULL;
         }

--- a/src/extension/php_objects.c
+++ b/src/extension/php_objects.c
@@ -203,6 +203,7 @@ int save_env_value_on_ini(char *ini_name, zend_string *env_value) /* {{{ */
     } else {
         eex->has_env = false;
         zend_string_release(duplicate);
+        zend_string_efree(zs_ini_name);
         return FAILURE;
     }
 

--- a/src/extension/php_objects.c
+++ b/src/extension/php_objects.c
@@ -322,6 +322,19 @@ void dd_phpobj_shutdown()
 {
     zend_llist_destroy(&_function_entry_arrays);
     zend_unregister_ini_entries(_module_number);
+
+    struct _dd_registered_entries current;
+    while (registered_entries_count > 0) {
+        current = registered_entries[--registered_entries_count];
+        if (current.name) {
+            pefree(current.name, 1);
+            current.name = NULL;
+        }
+        if (current.env_name) {
+            pefree(current.env_name, 1);
+            current.env_name = NULL;
+        }
+    }
 }
 
 static void _unregister_functions(void *zfe_arr_vp)

--- a/src/extension/php_objects.c
+++ b/src/extension/php_objects.c
@@ -115,6 +115,11 @@ void dd_phpobj_reg_ini_env(const dd_ini_setting *sett)
         pefree(env_name, 1);
         env_name = NULL;
     }
+
+    if (name) {
+        pefree(name, 1);
+        name = NULL;
+    }
 }
 
 /*

--- a/src/extension/php_objects.c
+++ b/src/extension/php_objects.c
@@ -25,7 +25,7 @@ typedef struct _dd_registered_entries {
     char *nullable env_name;
 } dd_registered_entries;
 
-#define DD_MAX_REGISTERED_ENTRIES 160
+#define DD_MAX_REGISTERED_ENTRIES 50
 static uint8_t registered_entries_count = 0;
 static dd_registered_entries registered_entries[DD_MAX_REGISTERED_ENTRIES];
 #endif

--- a/src/extension/php_objects.c
+++ b/src/extension/php_objects.c
@@ -197,7 +197,7 @@ dd_result dd_phpobj_load_env_values()
         if (p->on_modify == _on_modify_wrapper &&
             ZSTR_LEN(p->name) > NAME_PREFIX_LEN) {
             const char *ini_name = ZSTR_VAL(p->name);
-            char *env_name = env_name =
+            char *env_name =
                 _get_env_name_from_ini_name(&ini_name[NAME_PREFIX_LEN],
                     ZSTR_LEN(p->name) - NAME_PREFIX_LEN);
             zend_string *env_def = _fetch_from_env(env_name);

--- a/src/extension/php_objects.h
+++ b/src/extension/php_objects.h
@@ -52,6 +52,7 @@ void dd_phpobj_startup(int module_number);
 dd_result dd_phpobj_reg_funcs(const zend_function_entry *entries);
 dd_result dd_phpobj_reg_ini(const zend_ini_entry_def *entries);
 void dd_phpobj_reg_ini_env(const dd_ini_setting *sett);
+dd_result dd_phpobj_load_env_values(void);
 static inline void dd_phpobj_reg_ini_envs(const dd_ini_setting *setts)
 {
     for (__auto_type s = setts; s->name_suff; s++) {

--- a/tests/docker/fpm-common/www.conf
+++ b/tests/docker/fpm-common/www.conf
@@ -20,3 +20,7 @@ security.limit_extensions = .php
 
 php_admin_value[error_log] = /tmp/php_error.log
 php_admin_flag[log_errors] = on
+
+;Default is 10000 so lets give it 1 more
+;in order to test pool envs
+env[DD_APPSEC_WAF_TIMEOUT] = "10001"

--- a/tests/extension/env_gets_priority_over_ini.phpt
+++ b/tests/extension/env_gets_priority_over_ini.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Settings made via ENV variables take priority over INI ones
+--ENV--
+DD_APPSEC_LOG_FILE=/env/path
+--INI--
+datadog.appsec.log_file=/some/path/on/ini
+--FILE--
+<?php
+var_dump(ini_get("datadog.appsec.log_file"));
+?>
+--EXPECT--
+string(9) "/env/path"

--- a/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Apache2FpmTests.groovy
+++ b/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Apache2FpmTests.groovy
@@ -60,4 +60,14 @@ class Apache2FpmTests implements CommonTests {
             'test $(find /tmp/cli/ -maxdepth 1 -type s -name \'ddappsec_*.sock\' | wc -l) -eq 1')
         assert res.exitCode == 0
     }
+
+    @Test
+    void 'Pool environment'() {
+        def trace = container.traceFromRequest('/poolenv.php') { HttpURLConnection conn ->
+            assert conn.responseCode == 200
+            def content = conn.inputStream.text
+
+            assert content.contains('Value of pool env is 10001')
+        }
+    }
 }


### PR DESCRIPTION
### Description

Currently whenever ini settings are registered, the environment variables are checked to verify if the default or ini value should be overridden. In php-fpm, the pool environment is only available after forking, so the settings are never overridden.

### Motivation

It can be the case that one of our customers using FPM sets pool environment this way expecting the extension to be configured in a specific way that it wont be because of this bug

### Additional Notes

The taken approach is not as optimal as the ones used on another extensions within DD. However, for now it is enough for the current state of the extension

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [x] The CHANGELOG.md has been updated


