### PR TITLE
Add a way to include local changes to the cmake build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ cscope.*
 /build/
 /compile_commands.json
 /.cache/
+
+#This file is only used for custom configurations on developer machines
+cmake/local.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,3 +45,11 @@ endif()
 
 include(cmake/clang-tidy.cmake)
 include(cmake/clang-format.cmake)
+
+# When you enable this option. The file cmake/local.cmake will be included as part of the build.
+# The file cmake/local.cmake is ignored by git. Feel free to add anything you need to support
+# your local build. One example this is used for is to tell Clion where to find PHP Sources
+option(DD_APPSEC_LOCAL_CONFIGURATIONS "Whether to include the local.cmake file content as part of the build process" OFF)
+if(DD_APPSEC_LOCAL_CONFIGURATIONS)
+    include(cmake/local.cmake)
+endif()


### PR DESCRIPTION
### Description

Some IDEs load libraries using CMake. Since our project also uses cmake for the build process, it is not possible to add these libraries easily on local machine and not pipeline ones. This PR adds an option to the CMake that when set, it also load a local cmake file where each dev is free to add any custom configuration required. This file is ignored by git.

### Motivation

Allowing Clion to follow PHP Headers

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


