### PR TITLE
Return error response in helper when incoming message can't be unpacked

### DIFF
--- a/src/extension/commands_helpers.c
+++ b/src/extension/commands_helpers.c
@@ -124,11 +124,13 @@ static dd_result _dd_command_exec(dd_conn *nonnull conn, bool check_cred,
     }
 
     if (should_block) {
-        mlog(dd_log_info, "request_init succeed and told to block");
+        mlog(dd_log_info, "%.*s succeed and told to block", (int)spec->name_len,
+            spec->name);
         return dd_should_block;
     }
 
-    mlog(dd_log_debug, "request_init succeed. Not blocking");
+    mlog(dd_log_debug, "%.*s succeed. Not blocking", (int)spec->name_len,
+        spec->name);
     return dd_success;
 }
 
@@ -201,6 +203,11 @@ static inline dd_result _dd_imsg_recv(
     }
     if (res) {
         return res;
+    }
+
+    if (imsg->_size == 1) {
+        mlog(dd_log_debug, "Helper sent error message");
+        return dd_error;
     }
 
     mpack_tree_init(&imsg->_tree, imsg->_data, imsg->_size);

--- a/src/extension/commands_helpers.c
+++ b/src/extension/commands_helpers.c
@@ -124,13 +124,11 @@ static dd_result _dd_command_exec(dd_conn *nonnull conn, bool check_cred,
     }
 
     if (should_block) {
-        mlog(dd_log_info, "%.*s succeed and told to block", (int)spec->name_len,
-            spec->name);
+        mlog(dd_log_info, "%.*s succeed and told to block", NAME_L);
         return dd_should_block;
     }
 
-    mlog(dd_log_debug, "%.*s succeed. Not blocking", (int)spec->name_len,
-        spec->name);
+    mlog(dd_log_debug, "%.*s succeed. Not blocking", NAME_L);
     return dd_success;
 }
 

--- a/src/extension/helper_process.c
+++ b/src/extension/helper_process.c
@@ -126,11 +126,11 @@ void dd_helper_shutdown(void)
 
 void dd_helper_rshutdown()
 {
-    _mgr.connected_this_req = false;
-    _mgr.launched_this_req = false;
     if (_mgr.connected_this_req && dd_conn_connected(&_mgr.conn)) {
         dd_conn_set_timeout(&_mgr.conn, comm_type_recv, timeout_recv_subseq);
     }
+    _mgr.connected_this_req = false;
+    _mgr.launched_this_req = false;
 }
 
 static bool _wait_for_next_retry(void);

--- a/src/extension/helper_process.c
+++ b/src/extension/helper_process.c
@@ -126,9 +126,6 @@ void dd_helper_shutdown(void)
 
 void dd_helper_rshutdown()
 {
-    if (_mgr.connected_this_req && dd_conn_connected(&_mgr.conn)) {
-        dd_conn_set_timeout(&_mgr.conn, comm_type_recv, timeout_recv_subseq);
-    }
     _mgr.connected_this_req = false;
     _mgr.launched_this_req = false;
 }
@@ -193,6 +190,9 @@ dd_conn *nullable dd_helper_mgr_acquire_conn(client_init_func nonnull init_func)
                 _prevent_launch_attempts(-1);
             }
             goto error;
+        } else {
+            dd_conn_set_timeout(
+                &_mgr.conn, comm_type_recv, timeout_recv_subseq);
         }
 
         // else success

--- a/src/extension/network.c
+++ b/src/extension/network.c
@@ -228,12 +228,6 @@ dd_result dd_conn_recv(dd_conn *nonnull conn, char *nullable *nonnull data,
         return dd_network; // force reconnect, we don't want to read it all
     }
 
-    // Empty msgpack case - this indicates the error message
-    if (h.size == 1) {
-        mlog(dd_log_warning, "Helper responded with an error message");
-        return dd_error;
-    }
-
     return _recv_message_body(conn->socket, data, data_len, h.size);
 }
 
@@ -411,6 +405,9 @@ dd_result dd_conn_set_timeout(
     struct timeval timeout;
     timeout.tv_sec = time_seconds;
     timeout.tv_usec = time_microseconds;
+
+    mlog(dd_log_debug, "setting timeout to %u.%06u", time_seconds,
+        time_microseconds);
 
     int res =
         setsockopt(conn->socket, SOL_SOCKET, type, &timeout, sizeof(timeout));

--- a/src/extension/network.c
+++ b/src/extension/network.c
@@ -228,6 +228,12 @@ dd_result dd_conn_recv(dd_conn *nonnull conn, char *nullable *nonnull data,
         return dd_network; // force reconnect, we don't want to read it all
     }
 
+    if (h.size == 0) {
+        mlog(dd_log_warning,
+            "Helper was unable to process message");
+        return dd_error;
+    }
+
     return _recv_message_body(conn->socket, data, data_len, h.size);
 }
 

--- a/src/extension/network.c
+++ b/src/extension/network.c
@@ -229,8 +229,7 @@ dd_result dd_conn_recv(dd_conn *nonnull conn, char *nullable *nonnull data,
     }
 
     if (h.size == 0) {
-        mlog(dd_log_warning,
-            "Helper was unable to process message");
+        mlog(dd_log_warning, "Helper was unable to process message");
         return dd_error;
     }
 

--- a/src/extension/network.c
+++ b/src/extension/network.c
@@ -228,8 +228,9 @@ dd_result dd_conn_recv(dd_conn *nonnull conn, char *nullable *nonnull data,
         return dd_network; // force reconnect, we don't want to read it all
     }
 
-    if (h.size == 0) {
-        mlog(dd_log_warning, "Helper was unable to process message");
+    // Empty msgpack case - this indicates the error message
+    if (h.size == 1) {
+        mlog(dd_log_warning, "Helper responded with an error message");
         return dd_error;
     }
 

--- a/src/helper/client.cpp
+++ b/src/helper/client.cpp
@@ -7,6 +7,7 @@
 
 #include "exception.hpp"
 #include "msgpack/object.h"
+#include "network/broker.hpp"
 #include "network/proto.hpp"
 #include "std_logging.hpp"
 #include <chrono>
@@ -50,6 +51,13 @@ bool maybe_exec_cmd_M(client &client, network::request &msg)
     return false;
 }
 
+void send_error_response(const network::base_broker &broker)
+{
+    if (!broker.send(network::error::response())) {
+        SPDLOG_WARN("Failed to send error response");
+    }
+}
+
 template <typename... Ms>
 // NOLINTNEXTLINE(google-runtime-references)
 bool handle_message(client &client, const network::base_broker &broker,
@@ -83,9 +91,10 @@ bool handle_message(client &client, const network::base_broker &broker,
     }
 
     if (send_error) {
-        if (!broker.send(network::error::response())) {
-            SPDLOG_WARN("Failed to send error response");
-        }
+        // This can happen due to a valid error, let's continue handling
+        // the client as this might just happen spuriously.
+        send_error_response(broker);
+        return true;
     }
 
     // If we reach this point, there was a problem handling the message
@@ -152,7 +161,9 @@ bool client::handle_command(const network::client_init::request &command)
 bool client::handle_command(network::request_init::request &command)
 {
     if (!engine_) {
+        // This implies a failed client_init, we can't continue.
         SPDLOG_DEBUG("no engine available on request_init");
+        send_error_response(*broker_);
         return false;
     }
 
@@ -178,10 +189,12 @@ bool client::handle_command(network::request_init::request &command)
         // This error indicates some issue in either the communication with
         // the client, incompatible versions or malicious client.
         SPDLOG_ERROR("invalid data format provided by the client");
+        send_error_response(*broker_);
         return false;
     } catch (const std::exception &e) {
         // Uncertain what the issue is... lets be cautious
         DD_STDLOG(DD_STDLOG_REQUEST_ANALYSIS_FAILED, e.what());
+        send_error_response(*broker_);
         return false;
     }
 
@@ -199,9 +212,17 @@ bool client::handle_command(network::request_init::request &command)
 bool client::handle_command(network::request_shutdown::request &command)
 {
     if (!context_) {
-        // A lack of context implies a bug somewhere
-        SPDLOG_DEBUG("no context available on request_shutdown");
-        return false;
+        // A lack of context implies processing request_init failed, this
+        // can happen for legitimate reasons so let's try to process the data.
+        if (!engine_) {
+            // This implies a failed client_init, we can't continue.
+            SPDLOG_DEBUG("no engine available on request_shutdown");
+            send_error_response(*broker_);
+            return false;
+        }
+
+        // During request init we initialize the engine contex
+        context_.emplace(*engine_);
     }
 
     SPDLOG_DEBUG("received command request_shutdown");
@@ -226,10 +247,12 @@ bool client::handle_command(network::request_shutdown::request &command)
         // This error indicates some issue in either the communication with
         // the client, incompatible versions or malicious client.
         SPDLOG_ERROR("invalid data format provided by the client");
+        send_error_response(*broker_);
         return false;
     } catch (const std::exception &e) {
         // Uncertain what the issue is... lets be cautious
         DD_STDLOG(DD_STDLOG_REQUEST_ANALYSIS_FAILED, e.what());
+        send_error_response(*broker_);
         return false;
     }
 
@@ -253,6 +276,8 @@ bool client::run_client_init()
 
 bool client::run_request()
 {
+    // TODO: figure out how to handle errors which require sending an error
+    //       response to ensure the extension doesn't hang.
     return handle_message<network::request_init, network::request_shutdown>(
         *this, *broker_, std::chrono::milliseconds{0} /* no initial timeout */
     );

--- a/src/helper/client.cpp
+++ b/src/helper/client.cpp
@@ -50,12 +50,6 @@ bool maybe_exec_cmd_M(client &client, network::request &msg)
     return false;
 }
 
-void send_error_response(const network::base_broker &broker)
-{
-    network::error_response err;
-    broker.send(err);
-}
-
 template <typename... Ms>
 // NOLINTNEXTLINE(google-runtime-references)
 bool handle_message(client &client, const network::base_broker &broker,
@@ -88,7 +82,9 @@ bool handle_message(client &client, const network::base_broker &broker,
         SPDLOG_WARN("Failed to handle message: {}", e.what());
     }
 
-    if (send_error) { send_error_response(broker); }
+    if (send_error) {
+        broker.send(network::error_response());
+    }
 
     // If we reach this point, there was a problem handling the message
     return false;

--- a/src/helper/client.cpp
+++ b/src/helper/client.cpp
@@ -83,7 +83,9 @@ bool handle_message(client &client, const network::base_broker &broker,
     }
 
     if (send_error) {
-        broker.send(network::error_response());
+        if (!broker.send(network::error::response())) {
+            SPDLOG_WARN("Failed to send error response");
+        }
     }
 
     // If we reach this point, there was a problem handling the message

--- a/src/helper/network/broker.cpp
+++ b/src/helper/network/broker.cpp
@@ -38,6 +38,7 @@ request broker::recv(std::chrono::milliseconds initial_timeout) const
             "Not enough data for header:" + std::to_string(res) + " bytes");
     }
 
+    // TODO: remove or increase this dramatically with WAF 1.5.0
     static msgpack::unpack_limit limits(max_array_size, max_map_size,
         max_string_length, max_binary_size, max_extension_size, max_depth);
 

--- a/src/helper/network/broker.cpp
+++ b/src/helper/network/broker.cpp
@@ -33,7 +33,7 @@ request broker::recv(std::chrono::milliseconds initial_timeout) const
         throw client_disconnect{};
     }
     if (res != sizeof(header_t)) {
-        // The ender probably closed the socket
+        // The sender probably closed the socket
         throw std::length_error(
             "Not enough data for header:" + std::to_string(res) + " bytes");
     }

--- a/src/helper/network/broker.cpp
+++ b/src/helper/network/broker.cpp
@@ -85,6 +85,10 @@ bool broker::send(const base_response &msg) const
         return false;
     }
 
+    if (buffer.size() == 0) {
+        return 0;
+    }
+
     res = socket_->send(buffer.c_str(), buffer.size());
     return res == buffer.size();
 }

--- a/src/helper/network/broker.cpp
+++ b/src/helper/network/broker.cpp
@@ -33,7 +33,7 @@ request broker::recv(std::chrono::milliseconds initial_timeout) const
         throw client_disconnect{};
     }
     if (res != sizeof(header_t)) {
-        // The sender probably closed the socket
+        // The ender probably closed the socket
         throw std::length_error(
             "Not enough data for header:" + std::to_string(res) + " bytes");
     }
@@ -83,10 +83,6 @@ bool broker::send(const base_response &msg) const
     auto res = socket_->send(reinterpret_cast<char *>(&h), sizeof(header_t));
     if (res != sizeof(header_t)) {
         return false;
-    }
-
-    if (buffer.size() == 0) {
-        return 0;
     }
 
     res = socket_->send(buffer.c_str(), buffer.size());

--- a/src/helper/network/proto.cpp
+++ b/src/helper/network/proto.cpp
@@ -32,7 +32,11 @@ request_id command_name_to_id(const std::string &str)
 template <typename T> auto msgpack_to_request(const msgpack::object &o)
 {
     using R = typename T::request;
-    return std::make_shared<R>(o.as<R>());
+    try {
+        return std::make_shared<R>(o.as<R>());
+    } catch (...) {
+        return std::make_shared<R>();
+    }
 }
 
 } // namespace

--- a/src/helper/network/proto.hpp
+++ b/src/helper/network/proto.hpp
@@ -168,9 +168,11 @@ struct request_shutdown {
 // Response to be used if the incoming message could not be parsed, this
 // response ensures that the extension will not be blocked waiting for a
 // message.
-struct error_response : base_response_generic<error_response> {
-    static constexpr response_id id = response_id::error;
-    MSGPACK_DEFINE();
+struct error {
+    struct response : base_response_generic<response> {
+        static constexpr response_id id = response_id::error;
+        MSGPACK_DEFINE();
+    };
 };
 
 struct request {

--- a/src/helper/network/proto.hpp
+++ b/src/helper/network/proto.hpp
@@ -33,7 +33,8 @@ enum class response_id : unsigned {
     unknown,
     client_init,
     request_init,
-    request_shutdown
+    request_shutdown,
+    error
 };
 
 struct base_request {
@@ -162,6 +163,14 @@ struct request_shutdown {
 
         MSGPACK_DEFINE(verdict, triggers, meta, metrics);
     };
+};
+
+// Response to be used if the incoming message could not be parsed, this
+// response ensures that the extension will not be blocked waiting for a
+// message.
+struct error_response : base_response_generic<error_response> {
+    static constexpr response_id id = response_id::error;
+    MSGPACK_DEFINE();
 };
 
 struct request {

--- a/tests/helper/broker_test.cpp
+++ b/tests/helper/broker_test.cpp
@@ -272,8 +272,9 @@ TEST(BrokerTest, RecvRequestInitOverLimits)
         .WillOnce(
             DoAll(CopyString(&expected_data), Return(expected_data.size())));
 
-    EXPECT_THROW(network::request request = broker.recv(std::chrono::milliseconds(100)),
-            msgpack::unpack_error);
+    EXPECT_THROW(
+        network::request request = broker.recv(std::chrono::milliseconds(100)),
+        msgpack::unpack_error);
 }
 
 TEST(BrokerTest, RecvRequestShutdown)

--- a/tests/helper/broker_test.cpp
+++ b/tests/helper/broker_test.cpp
@@ -249,6 +249,33 @@ TEST(BrokerTest, RecvRequestInit)
     EXPECT_STREQ(std::string_view(pv[1]).data(), "arachni.com");
 }
 
+TEST(BrokerTest, RecvRequestInitOverLimits)
+{
+    mock::socket *socket = new mock::socket();
+    network::broker broker{std::unique_ptr<mock::socket>(socket)};
+
+    std::stringstream ss;
+    msgpack::packer<std::stringstream> packer(ss);
+    packer.pack_array(2);
+    pack_str(packer, "request_init");
+    packer.pack_array(1);
+    packer.pack_map(257);
+    for (unsigned i = 0; i < 257; i++) {
+        pack_str(packer, std::to_string(i));
+        pack_str(packer, std::to_string(i));
+    }
+    const std::string &expected_data = ss.str();
+
+    network::header_t h{"dds", (uint32_t)expected_data.size()};
+    EXPECT_CALL(*socket, recv(_, _))
+        .WillOnce(DoAll(CopyHeader(&h), Return(sizeof(network::header_t))))
+        .WillOnce(
+            DoAll(CopyString(&expected_data), Return(expected_data.size())));
+
+    EXPECT_THROW(network::request request = broker.recv(std::chrono::milliseconds(100)),
+            msgpack::unpack_error);
+}
+
 TEST(BrokerTest, RecvRequestShutdown)
 {
     mock::socket *socket = new mock::socket();

--- a/tests/helper/broker_test.cpp
+++ b/tests/helper/broker_test.cpp
@@ -259,8 +259,10 @@ TEST(BrokerTest, RecvRequestInitOverLimits)
     packer.pack_array(2);
     pack_str(packer, "request_init");
     packer.pack_array(1);
-    packer.pack_map(257);
-    for (unsigned i = 0; i < 257; i++) {
+
+    auto map_size = network::broker::max_map_size + 1;
+    packer.pack_map(map_size);
+    for (unsigned i = 0; i < map_size; i++) {
         pack_str(packer, std::to_string(i));
         pack_str(packer, std::to_string(i));
     }

--- a/tests/helper/broker_test.cpp
+++ b/tests/helper/broker_test.cpp
@@ -582,10 +582,16 @@ TEST(BrokerTest, SendErrorResponse)
     mock::socket *socket = new mock::socket();
     network::broker broker{std::unique_ptr<mock::socket>(socket)};
 
-    EXPECT_CALL(*socket, send(_, _)).WillOnce(Return(0));
+    network::header_t h;
+    EXPECT_CALL(*socket, send(_, _))
+        .WillOnce(DoAll(SaveHeader(&h), Return(sizeof(network::header_t))))
+        .WillOnce(Return(1));
 
     network::error::response response;
-    EXPECT_FALSE(broker.send(response));
+    EXPECT_TRUE(broker.send(response));
+
+    EXPECT_STREQ(h.code, "dds");
+    EXPECT_EQ(h.size, 1);
 }
 
 TEST(BrokerTest, InvalidResponseSize)

--- a/tests/helper/broker_test.cpp
+++ b/tests/helper/broker_test.cpp
@@ -577,13 +577,21 @@ TEST(BrokerTest, ParsingBodyLimit)
         std::length_error);
 }
 
-TEST(BrokerTest, InvalidResponseSize)
+TEST(BrokerTest, SendErrorResponse)
 {
     mock::socket *socket = new mock::socket();
     network::broker broker{std::unique_ptr<mock::socket>(socket)};
 
-    std::stringstream ss;
-    msgpack::packer<std::stringstream> packer(ss);
+    EXPECT_CALL(*socket, send(_, _)).WillOnce(Return(0));
+
+    network::error::response response;
+    EXPECT_FALSE(broker.send(response));
+}
+
+TEST(BrokerTest, InvalidResponseSize)
+{
+    mock::socket *socket = new mock::socket();
+    network::broker broker{std::unique_ptr<mock::socket>(socket)};
 
     EXPECT_CALL(*socket, send(_, _)).WillOnce(Return(0));
 

--- a/tests/helper/client_test.cpp
+++ b/tests/helper/client_test.cpp
@@ -385,7 +385,7 @@ TEST(ClientTest, RequestInitUnpackError)
 
     // Request Init
     {
-        network::error_response res;
+        network::error::response res;
         EXPECT_CALL(*broker, recv(_))
             .WillOnce(Throw(msgpack::unpack_error("map size overflow")));
         EXPECT_CALL(*broker, send(_))

--- a/tests/helper/client_test.cpp
+++ b/tests/helper/client_test.cpp
@@ -386,7 +386,8 @@ TEST(ClientTest, RequestInitUnpackError)
     // Request Init
     {
         network::error_response res;
-        EXPECT_CALL(*broker, recv(_)).WillOnce(Throw(msgpack::unpack_error("map size overflow")));
+        EXPECT_CALL(*broker, recv(_))
+            .WillOnce(Throw(msgpack::unpack_error("map size overflow")));
         EXPECT_CALL(*broker, send(_))
             .WillOnce(DoAll(SaveResponse<decltype(res)>(&res), Return(true)));
 

--- a/tests/helper/client_test.cpp
+++ b/tests/helper/client_test.cpp
@@ -391,7 +391,7 @@ TEST(ClientTest, RequestInitUnpackError)
         EXPECT_CALL(*broker, send(_))
             .WillOnce(DoAll(SaveResponse<decltype(res)>(&res), Return(true)));
 
-        EXPECT_FALSE(c.run_request());
+        EXPECT_TRUE(c.run_request());
     }
 }
 
@@ -412,7 +412,7 @@ TEST(ClientTest, RequestInitNoClientInit)
         network::request req(std::move(msg));
 
         EXPECT_CALL(*broker, recv(_)).WillOnce(Return(req));
-        EXPECT_CALL(*broker, send(_)).Times(0);
+        EXPECT_CALL(*broker, send(_)).WillOnce(Return(true));
 
         EXPECT_FALSE(c.run_request());
     }
@@ -453,7 +453,7 @@ TEST(ClientTest, RequestInitInvalidData)
         network::request req(std::move(msg));
 
         EXPECT_CALL(*broker, recv(_)).WillOnce(Return(req));
-        EXPECT_CALL(*broker, send(_)).Times(0);
+        EXPECT_CALL(*broker, send(_)).WillOnce(Return(true));
 
         EXPECT_FALSE(c.run_request());
     }
@@ -643,7 +643,7 @@ TEST(ClientTest, RequestShutdownInvalidData)
 
         network::request_shutdown::response res;
         EXPECT_CALL(*broker, recv(_)).WillOnce(Return(req));
-        EXPECT_CALL(*broker, send(_)).Times(0);
+        EXPECT_CALL(*broker, send(_)).WillOnce(Return(true));
 
         EXPECT_FALSE(c.run_request());
     }
@@ -664,7 +664,7 @@ TEST(ClientTest, RequestShutdownNoClientInit)
         network::request req(std::move(msg));
 
         EXPECT_CALL(*broker, recv(_)).WillOnce(Return(req));
-        EXPECT_CALL(*broker, send(_)).Times(0);
+        EXPECT_CALL(*broker, send(_)).WillOnce(Return(true));
 
         EXPECT_FALSE(c.run_request());
     }
@@ -704,10 +704,14 @@ TEST(ClientTest, RequestShutdownNoRequestInit)
 
         network::request req(std::move(msg));
 
+        network::request_init::response res;
         EXPECT_CALL(*broker, recv(_)).WillOnce(Return(req));
-        EXPECT_CALL(*broker, send(_)).Times(0);
+        EXPECT_CALL(*broker, send(_))
+            .WillOnce(DoAll(SaveResponse<decltype(res)>(&res), Return(true)));
 
-        EXPECT_FALSE(c.run_request());
+        EXPECT_TRUE(c.run_request());
+        EXPECT_STREQ(res.verdict.c_str(), "ok");
+        EXPECT_EQ(res.triggers.size(), 0);
     }
 }
 


### PR DESCRIPTION
### Description

When the helper process is unable to process an incoming message (too small, too large, fail to unpack due to limits, etc), the message will be ignored and the extension will be blocked until timeout.

This PR introduces an empty `error_response` which can be sent to the extension whenever the incoming message can't be processed, this ensures that the extension isn't blocked and the message response will be discarded without further action.

### Additional Notes

For now this is a hotfix as there seems to be more than one customer affected by this. A broader solution to this problem will be provided in v0.5.0.

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


