### PR TITLE
Handle helper errors gracefully

### DIFF
--- a/src/extension/commands_helpers.c
+++ b/src/extension/commands_helpers.c
@@ -96,8 +96,11 @@ static dd_result _dd_command_exec(dd_conn *nonnull conn, bool check_cred,
             res = _imsg_recv(&imsg, conn);
         }
         if (res) {
-            mlog(dd_log_warning, "Error receiving reply for command %.*s: %s",
-                NAME_L, dd_result_to_string(res));
+            if (res != dd_helper_error) {
+                mlog(dd_log_warning,
+                    "Error receiving reply for command %.*s: %s", NAME_L,
+                    dd_result_to_string(res));
+            }
             return res;
         }
 
@@ -204,8 +207,9 @@ static inline dd_result _dd_imsg_recv(
     }
 
     if (imsg->_size == 1) {
-        mlog(dd_log_debug, "Helper sent error message");
-        return dd_error;
+        // The helper process sent an error response, this is a non-fatal
+        // error to indicate the message could not be processed.
+        return dd_helper_error;
     }
 
     mpack_tree_init(&imsg->_tree, imsg->_data, imsg->_size);

--- a/src/extension/dddefs.c
+++ b/src/extension/dddefs.c
@@ -16,6 +16,10 @@ const char *nonnull dd_result_to_string(dd_result result)
         return "dd_should_block";
     case dd_error:
         return "dd_error";
+    case dd_try_later:
+        return "dd_try_later";
+    case dd_helper_error:
+        return "dd_helper_error";
     default:
         return "unknown";
     }

--- a/src/extension/dddefs.h
+++ b/src/extension/dddefs.h
@@ -14,7 +14,8 @@ typedef enum {
     dd_network,      // error in communication; connection should be abandoned
     dd_should_block, // caller should abort the request
     dd_error,        // misc error
-    dd_try_later,        // misc error
+    dd_try_later,    // non-fatal error, try again
+    dd_helper_error  // helper failed to process message (non-fatal)
 } dd_result;
 
 const char *nonnull dd_result_to_string(dd_result result);


### PR DESCRIPTION
### Description

Handle the helper error response gracefully, since this is meant to signify a message which could not be parsed, usually due to exceeding certain limits. This means the message and the request themselves might be valid but are rejected for legitimate safety reasons, so we don't need to spam the user with error message as this might happen often with an application which has endpoints requiring a number of parameters or body size surpassing those.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


