### PR TITLE
Replace actor.ip with http.client_ip

### DIFF
--- a/src/extension/tags.c
+++ b/src/extension/tags.c
@@ -23,7 +23,6 @@
 #define DD_TAG_HTTP_STATUS_CODE "http.status_code"
 #define DD_TAG_HTTP_URL "http.url"
 #define DD_TAG_NETWORK_CLIENT_IP "network.client.ip"
-#define DD_TAG_ACTOR_IP "actor.ip"
 #define DD_PREFIX_TAG_REQUEST_HEADER "http.request.headers."
 #define DD_TAG_HTTP_RH_CONTENT_LENGTH "http.response.headers.content-length"
 #define DD_TAG_HTTP_RH_CONTENT_TYPE "http.response.headers.content-type"
@@ -41,7 +40,6 @@ static zend_string *_dd_tag_http_user_agent_zstr;
 static zend_string *_dd_tag_http_status_code_zstr;
 static zend_string *_dd_tag_http_url_zstr;
 static zend_string *_dd_tag_network_client_ip_zstr;
-static zend_string *_dd_tag_actor_ip_zstr;
 static zend_string *_dd_tag_http_client_ip_zstr;
 static zend_string *_dd_tag_rh_content_length;   // response
 static zend_string *_dd_tag_rh_content_type;     // response
@@ -87,8 +85,6 @@ void dd_tags_startup()
         zend_string_init_interned(LSTRARG(DD_TAG_HTTP_URL), 1);
     _dd_tag_network_client_ip_zstr =
         zend_string_init_interned(LSTRARG(DD_TAG_NETWORK_CLIENT_IP), 1);
-    _dd_tag_actor_ip_zstr =
-        zend_string_init_interned(LSTRARG(DD_TAG_ACTOR_IP), 1);
     _dd_tag_http_client_ip_zstr =
         zend_string_init_interned(LSTRARG(DD_TAG_HTTP_CLIENT_IP), 1);
 
@@ -332,7 +328,7 @@ static void _dd_http_url(zend_array *meta_ht, zval *_server);
 static void _dd_http_user_agent(zend_array *meta_ht, zval *_server);
 static void _dd_http_status_code(zend_array *meta_ht);
 static void _dd_http_network_client_ip(zend_array *meta_ht, zval *_server);
-static void _dd_actor_ip(zend_array *meta_ht, zval *_server);
+static void _dd_http_client_ip(zend_array *meta_ht, zval *_server);
 static void _dd_request_headers(zend_array *meta_ht, zval *_server);
 static void _dd_response_headers(zend_array *meta_ht);
 
@@ -355,13 +351,12 @@ static void _add_all_tags_to_meta(zval *nonnull meta)
         mlog(dd_log_info, "No SERVER autoglobal available");
         return;
     }
-
     _dd_http_method(meta_ht);
     _dd_http_url(meta_ht, _server);
     _dd_http_user_agent(meta_ht, _server);
     _dd_http_status_code(meta_ht);
     _dd_http_network_client_ip(meta_ht, _server);
-    _dd_actor_ip(meta_ht, _server);
+    _dd_http_client_ip(meta_ht, _server);
     _dd_request_headers(meta_ht, _server);
     _dd_response_headers(meta_ht);
 }
@@ -494,24 +489,21 @@ static void _dd_http_network_client_ip(zend_array *meta_ht, zval *_server)
         meta_ht, _dd_tag_network_client_ip_zstr, remote_addr_zstr, true);
 }
 
-static void _dd_actor_ip(zend_array *meta_ht, zval *_server)
+static void _dd_http_client_ip(zend_array *meta_ht, zval *_server)
 {
-    if (zend_hash_exists(meta_ht, _dd_tag_actor_ip_zstr)) {
-        return;
-    }
-    // When http.client_ip comes from tracer, we use it as actor.ip
-    zval *client_ip = zend_hash_find(meta_ht, _dd_tag_http_client_ip_zstr);
-    if (client_ip != NULL && Z_TYPE_P(client_ip) == IS_STRING) {
-        _add_new_zstr_to_meta(
-            meta_ht, _dd_tag_actor_ip_zstr, Z_STR_P(client_ip), false);
-        return;
-    }
-    zend_string *actor_ip_zstr = dd_ip_extraction_find(_server);
-    if (!actor_ip_zstr) {
+    // If the tracer has set http.client_ip, there is nothing to do here
+    // otherwise, this header must be generated here
+    if (zend_hash_exists(meta_ht, _dd_tag_http_client_ip_zstr)) {
         return;
     }
 
-    _add_new_zstr_to_meta(meta_ht, _dd_tag_actor_ip_zstr, actor_ip_zstr, false);
+    zend_string *client_ip = dd_ip_extraction_find(_server);
+    if (!client_ip) {
+        return;
+    }
+
+    _add_new_zstr_to_meta(
+        meta_ht, _dd_tag_http_client_ip_zstr, client_ip, false);
 }
 
 static void _dd_request_headers(zend_array *meta_ht, zval *_server)

--- a/tests/extension/ancillary_tags.phpt
+++ b/tests/extension/ancillary_tags.phpt
@@ -58,7 +58,7 @@ print_r($arr);
 --EXPECTF--
 Array
 (
-    [actor.ip] => 7.7.7.7
+    [http.client_ip] => 7.7.7.7
     [http.method] => GET
     [http.request.headers.accept] => */*
     [http.request.headers.accept-encoding] => gzip

--- a/tests/extension/ancillary_tags_no_replace.phpt
+++ b/tests/extension/ancillary_tags_no_replace.phpt
@@ -30,7 +30,7 @@ $arr = array(
     'http.status_code' => '405',
     'http.response.headers.content-type' => 'text/xml',
     'network.client.ip' => '2.2.2.2',
-    'actor.ip' => '5.5.5.5'
+    'http.client_ip' => '5.5.5.5'
 );
 add_ancillary_tags($arr);
 ksort($arr);
@@ -40,7 +40,7 @@ print_r($arr);
 --EXPECTF--
 Array
 (
-    [actor.ip] => 5.5.5.5
+    [http.client_ip] => 5.5.5.5
     [http.method] => POST
     [http.request.headers.user-agent] => my user agent
     [http.request.headers.x-forwarded-for] => 8.8.8.8

--- a/tests/extension/http_client_ip.phpt
+++ b/tests/extension/http_client_ip.phpt
@@ -1,0 +1,23 @@
+--TEST--
+http.client_ip is generated when not already done so
+--ENV--
+HTTP_X_FORWARDED_FOR=7.7.7.7
+--FILE--
+<?php
+use function datadog\appsec\testing\add_ancillary_tags;
+
+$with_ip_generated = array(
+'http.client_ip' => 'ip generated somewhere else'
+);
+add_ancillary_tags($with_ip_generated);
+
+$without_ip_generated = array();
+add_ancillary_tags($without_ip_generated);
+
+var_dump($with_ip_generated['http.client_ip']);
+var_dump($without_ip_generated['http.client_ip']);
+
+?>
+--EXPECTF--
+string(27) "ip generated somewhere else"
+string(7) "7.7.7.7"

--- a/tests/extension/http_client_ip_generation_01.phpt
+++ b/tests/extension/http_client_ip_generation_01.phpt
@@ -1,0 +1,45 @@
+--TEST--
+ddtrace generates http.client_ip
+--INI--
+extension=ddtrace.so
+datadog.appsec.log_file=/tmp/php_appsec_test.log
+datadog.appsec.log_level=debug
+--ENV--
+HTTP_X_FORWARDED_FOR=7.7.7.7
+DD_TRACE_CLIENT_IP_HEADER_DISABLED=false
+--GET--
+key=val
+--FILE--
+<?php
+use function datadog\appsec\testing\{rinit,ddtrace_rshutdown,rshutdown,mlog};
+use const datadog\appsec\testing\log_level\DEBUG;
+include __DIR__ . '/inc/ddtrace_version.php';
+
+ddtrace_version_at_least('0.79.0');
+
+include __DIR__ . '/inc/mock_helper.php';
+
+$helper = Helper::createInitedRun([
+    ['record', ['{"found":"attack"}','{"another":"attack"}']],
+    ['record', ['{"yet another":"attack"}'], ["rshutdown_tag" => "rshutdown_value"], ["rshutdown_metric" => 2.1]],
+], ['continuous' => true]);
+
+
+rinit();
+$helper->get_commands(); //ignore
+
+rshutdown();
+$helper->get_commands(); //ignore
+
+ddtrace_rshutdown();
+dd_trace_internal_fn('synchronous_flush');
+
+$commands = $helper->get_commands();
+$tags = $commands[0]['payload'][0][0]['meta'];
+
+var_dump($tags['http.client_ip']);
+
+$helper->finished_with_commands();
+?>
+--EXPECTF--
+string(7) "7.7.7.7"

--- a/tests/extension/http_client_ip_generation_02.phpt
+++ b/tests/extension/http_client_ip_generation_02.phpt
@@ -1,0 +1,45 @@
+--TEST--
+ddappsec generates generates http.client_ip when ddtrace does not
+--INI--
+extension=ddtrace.so
+datadog.appsec.log_file=/tmp/php_appsec_test.log
+datadog.appsec.log_level=debug
+--ENV--
+HTTP_X_FORWARDED_FOR=7.7.7.7
+DD_TRACE_CLIENT_IP_HEADER_DISABLED=true
+--GET--
+key=val
+--FILE--
+<?php
+use function datadog\appsec\testing\{rinit,ddtrace_rshutdown,rshutdown,mlog};
+use const datadog\appsec\testing\log_level\DEBUG;
+include __DIR__ . '/inc/ddtrace_version.php';
+
+ddtrace_version_at_least('0.79.0');
+
+include __DIR__ . '/inc/mock_helper.php';
+
+$helper = Helper::createInitedRun([
+    ['record', ['{"found":"attack"}','{"another":"attack"}']],
+    ['record', ['{"yet another":"attack"}'], ["rshutdown_tag" => "rshutdown_value"], ["rshutdown_metric" => 2.1]],
+], ['continuous' => true]);
+
+
+rinit();
+$helper->get_commands(); //ignore
+
+rshutdown();
+$helper->get_commands(); //ignore
+
+ddtrace_rshutdown();
+dd_trace_internal_fn('synchronous_flush');
+
+$commands = $helper->get_commands();
+$tags = $commands[0]['payload'][0][0]['meta'];
+
+var_dump($tags['http.client_ip']);
+
+$helper->finished_with_commands();
+?>
+--EXPECTF--
+string(7) "7.7.7.7"


### PR DESCRIPTION
The tag `actor.ip` has been deprecated. Instead `http.client_ip` is the one which needs to be generated. This PR introduced an strategy for generating it. It is expected the ddtracer generates this tag but in case it is missing, ddapsec will do so.