### PR TITLE
Handle errors on request_shutdown

### DIFF
--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -310,12 +310,13 @@ int dd_appsec_rshutdown()
     if (conn) {
         int res = dd_request_shutdown(conn);
         if (res == dd_network) {
-            mlog_g(dd_log_info, "request_shutdown failed with dd_network; closing "
-                                "connection to helper");
+            mlog_g(dd_log_info,
+                "request_shutdown failed with dd_network; closing "
+                "connection to helper");
             dd_helper_close_conn();
         } else if (res) {
-            mlog_g(
-                dd_log_info, "request shutdown failed: %s", dd_result_to_string(res));
+            mlog_g(dd_log_info, "request shutdown failed: %s",
+                dd_result_to_string(res));
         }
     }
 

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -308,8 +308,15 @@ int dd_appsec_rshutdown()
 {
     dd_conn *conn = dd_helper_mgr_cur_conn();
     if (conn) {
-        // currently does nothing
-        UNUSED(dd_request_shutdown(conn));
+        int res = dd_request_shutdown(conn);
+        if (res == dd_network) {
+            mlog_g(dd_log_info, "request_shutdown failed with dd_network; closing "
+                                "connection to helper");
+            dd_helper_close_conn();
+        } else if (res) {
+            mlog_g(
+                dd_log_info, "request shutdown failed: %s", dd_result_to_string(res));
+        }
     }
 
     dd_helper_rshutdown();


### PR DESCRIPTION
### Description

When `request_shutdown` with side-effects was introduced, the appropriate `RSHUTDOWN` code was not updated to handle errors. This simply requires closing the connection when a network error is received and log a message otherwise.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


