### PR TITLE
Update ddtrace-basic test to be compatible with older tracers

### DIFF
--- a/tests/extension/ddtrace_basic.phpt
+++ b/tests/extension/ddtrace_basic.phpt
@@ -37,7 +37,16 @@ echo 'number of commands: ', count($c), "\n";
 \DDTrace\add_global_tag('ddappsec', 'true');
 
 DDTrace\start_span();
-var_dump(\DDTrace\root_span());
+
+// Compatibility with pre 0.81.0 
+$root_span = \DDTrace\root_span();
+if (property_exists($root_span, 'parent')) {
+    unset($root_span->parent);
+}
+if (property_exists($root_span, 'stack')) {
+    unset($root_span->stack);
+}
+var_dump($root_span);
 
 $trace_id = \DDTrace\trace_id();
 echo 'trace id: ', $trace_id, "\n";
@@ -85,20 +94,6 @@ object(DDTrace\SpanData)#%d (%d) {
   }
   ["id"]=>
   string(%d) "%d"
-  ["parent"]=>
-  NULL
-  ["stack"]=>
-  object(DDTrace\SpanStack)#%d (2) {
-    ["parent"]=>
-    object(DDTrace\SpanStack)#%d (2) {
-      ["parent"]=>
-      NULL
-      ["active"]=>
-      NULL
-    }
-    ["active"]=>
-    *RECURSION*
-  }
 }
 trace id: %s
 ddtrace_rshutdown


### PR DESCRIPTION
### Description

The span in the current master version of the tracer contains fields which aren't present in any of the released versions, the test has now been updated to explicitly remove incompatible fields from the span.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


