### PR TITLE
Fix msgpack inconsistency in remote config settings

### DIFF
--- a/src/helper/remote_config/client.cpp
+++ b/src/helper/remote_config/client.cpp
@@ -46,8 +46,8 @@ client::ptr client::from_settings(
         return {};
     }
     return std::make_unique<client>(
-        std::make_unique<http_api>(settings.host, settings.port), sid,
-        settings);
+        std::make_unique<http_api>(settings.host, std::to_string(settings.port)),
+        sid, settings);
 }
 
 [[nodiscard]] protocol::get_configs_request client::generate_request() const

--- a/src/helper/remote_config/settings.hpp
+++ b/src/helper/remote_config/settings.hpp
@@ -26,7 +26,7 @@ struct settings {
     // Remote config settings
     bool enabled{false};
     std::string host;
-    std::string port;
+    unsigned port;
     std::uint32_t poll_interval = default_poll_interval;
     std::uint64_t max_payload_size = default_max_payload_size;
 

--- a/src/helper/service_identifier.hpp
+++ b/src/helper/service_identifier.hpp
@@ -17,7 +17,7 @@ struct service_identifier {
     std::string app_version;
     std::string runtime_id;
 
-    MSGPACK_DEFINE_MAP(service, env);
+    MSGPACK_DEFINE_MAP(service, env, tracer_version, app_version, runtime_id);
 
     bool operator==(const service_identifier &oth) const noexcept
     {


### PR DESCRIPTION
### Description

A type inconsistency in the remote config settings was causing the `client_init` msgpack to fail.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


