### PR TITLE
Avoid regenerating ip when multiple headers are already present

### DIFF
--- a/src/extension/tags.c
+++ b/src/extension/tags.c
@@ -550,7 +550,8 @@ static void _extract_dd_multiple_ip_headers(
 
 static void _dd_http_client_ip(zend_array *meta_ht, zval *_server)
 {
-    if (zend_hash_exists(meta_ht, _dd_tag_http_client_ip_zstr)) {
+    if (zend_hash_exists(meta_ht, _dd_tag_http_client_ip_zstr) ||
+        zend_hash_exists(meta_ht, _dd_multiple_ip_headers)) {
         return;
     }
 

--- a/tests/extension/ancillary_tags_dont_regenerate_ip-headers.phpt
+++ b/tests/extension/ancillary_tags_dont_regenerate_ip-headers.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Test headers ip generation does not happen twice when meta has it already
+--INI--
+datadog.appsec.extra_headers=,mY-header,,my-other-header
+--ENV--
+HTTP_X_FORWARDED_FOR=7.7.7.7,10.0.0.1
+HTTP_X_CLIENT_IP=7.7.7.7
+HTTP_X_REAL_IP=7.7.7.8
+HTTP_X_FORWARDED=for="foo"
+HTTP_X_CLUSTER_CLIENT_IP=7.7.7.9
+HTTP_FORWARDED_FOR=7.7.7.10,10.0.0.1
+HTTP_FORWARDED=for="foo"
+HTTP_TRUE_CLIENT_IP=7.7.7.11
+HTTP_MY_HEADER=my header value
+HTTP_MY_OTHER_HEADER=my other header value
+REMOTE_ADDR=7.7.7.12
+--FILE--
+<?php
+
+use function datadog\appsec\testing\add_all_ancillary_tags;
+use function datadog\appsec\testing\add_basic_ancillary_tags;
+
+$all = array(
+    "_dd.multiple-ip-headers" => "headers already generated somewhere else"
+);
+add_all_ancillary_tags($all);
+var_dump($all["_dd.multiple-ip-headers"]);
+
+$basic = array(
+ "_dd.multiple-ip-headers" => "headers already generated somewhere else"
+);
+add_basic_ancillary_tags($basic);
+var_dump($basic["_dd.multiple-ip-headers"]);
+
+
+?>
+--EXPECTF--
+string(40) "headers already generated somewhere else"
+string(40) "headers already generated somewhere else"


### PR DESCRIPTION
### Description

Avoid generating IP when `_dd.multiple-ip-headers`  is already populated. This field `_dd.multiple-ip-headers` is created as result of the ip generation. If present, it means the ip extraction happened somewhere else and therefore, it does not have to happen again.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


