### PR TITLE
Generate runtime_id when not provided

### DIFF
--- a/src/helper/remote_config/client.cpp
+++ b/src/helper/remote_config/client.cpp
@@ -49,9 +49,17 @@ client::ptr client::from_settings(const service_identifier &sid,
         return {};
     }
 
+    // TODO runtime_id will be send by the extension when the extension can get
+    // it from the profiler. When that happen, this wont be needed
+    auto sid_copy = sid;
+    if (sid_copy.runtime_id.empty()) {
+        sid_copy.runtime_id = generate_random_uuid();
+    }
+
     return std::make_unique<client>(std::make_unique<http_api>(settings.host,
                                         std::to_string(settings.port)),
-        sid, settings, std::move(products), std::move(capabilities));
+        std::move(sid_copy), settings, std::move(products),
+        std::move(capabilities));
 }
 
 [[nodiscard]] protocol::get_configs_request client::generate_request() const

--- a/src/helper/remote_config/client.hpp
+++ b/src/helper/remote_config/client.hpp
@@ -50,6 +50,11 @@ public:
 
     virtual bool poll();
 
+    [[nodiscard]] const service_identifier &get_service_identifier()
+    {
+        return sid_;
+    }
+
 protected:
     [[nodiscard]] protocol::get_configs_request generate_request() const;
     bool process_response(const protocol::get_configs_response &response);

--- a/tests/helper/remote_config_client.cpp
+++ b/tests/helper/remote_config_client.cpp
@@ -1295,6 +1295,34 @@ TEST_F(RemoteConfigClient, OneClickActivationIsSetAsCapability)
     EXPECT_STREQ("Ag==", capabilities->value.GetString());
 }
 
+TEST_F(RemoteConfigClient, RuntimeIdIsNotGeneratedIfProvided)
+{
+    const char *runtime_id = "runtime_id";
+    service_identifier sid = {
+        "service", "env", "tracer_version", "app_version", runtime_id};
+
+    settings.enabled = true;
+
+    auto client = remote_config::client::from_settings(sid, settings, {}, {});
+
+    EXPECT_STREQ(
+        runtime_id, client->get_service_identifier().runtime_id.c_str());
+}
+
+TEST_F(RemoteConfigClient, RuntimeIdIsGeneratedWhenNotProvided)
+{
+    const char *runtime_id = "";
+    service_identifier sid = {
+        "service", "env", "tracer_version", "app_version", runtime_id};
+
+    settings.enabled = true;
+
+    auto client = remote_config::client::from_settings(sid, settings, {}, {});
+
+    EXPECT_FALSE(client->get_service_identifier().runtime_id.empty());
+    EXPECT_TRUE(sid.runtime_id.empty());
+}
+
 /*
 TEST_F(RemoteConfigClient, TestAgainstDocker)
 {


### PR DESCRIPTION
### Description

When extension does not provide runtime id, generate it on the helper. This will be remove on the future

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


