### PR TITLE
Misc fixes

### DIFF
--- a/src/extension/configuration.h
+++ b/src/extension/configuration.h
@@ -57,7 +57,7 @@ extern bool runtime_config_first_init;
     CONFIG(CUSTOM(uint32_t), DD_REMOTE_CONFIG_POLL_INTERVAL, "1000", .parser = _parse_uint32)                   \
     CONFIG(CUSTOM(uint64_t), DD_REMOTE_CONFIG_MAX_PAYLOAD_SIZE, "4096", .parser = _parse_uint64)                \
     CONFIG(STRING, DD_AGENT_HOST, "")                                                                           \
-    CONFIG(INT, DD_TRACE_AGENT_PORT, "8126")                                                                    \
+    CONFIG(INT, DD_TRACE_AGENT_PORT, "0")                                                                       \
     CONFIG(STRING, DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML, "")                                                    \
     CONFIG(STRING, DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON, "")
     // clang-format on

--- a/src/helper/remote_config/http_api.hpp
+++ b/src/helper/remote_config/http_api.hpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <optional>
+#include <spdlog/spdlog.h>
 #include <string>
 
 namespace beast = boost::beast; // from <boost/beast.hpp>
@@ -98,8 +99,7 @@ public:
             }
             // If we get here then the connection is closed gracefully
         } catch (std::exception const &e) {
-            //@todo log these errors somewhere else
-            //            std::cerr << "Error: " << e.what() << std::endl;
+            SPDLOG_ERROR("Connection error - {}", e.what());
             return std::nullopt;
         }
         return result;


### PR DESCRIPTION
### Description

- Log http errors when calling remote config endpoint
- Align default agent port with tracer. Changed from `8126` to `0`

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


