### PR TITLE
Remove ASM_ACTIVATION capability if enabled by configuration

### DIFF
--- a/src/helper/client.cpp
+++ b/src/helper/client.cpp
@@ -123,9 +123,18 @@ bool client::handle_command(const network::client_init::request &command)
 
     client_enabled_conf = command.enabled_configuration;
 
+    std::vector<remote_config::protocol::capabilities_e> capabilities = {
+        remote_config::protocol::capabilities_e::ASM_IP_BLOCKING,
+    };
+
+    if (!client_enabled_conf.has_value()) {
+        capabilities.push_back(
+            remote_config::protocol::capabilities_e::ASM_ACTIVATION);
+    }
+
     try {
-        service_ = service_manager_->create_service(
-            service_id, eng_settings, command.rc_settings, meta, metrics);
+        service_ = service_manager_->create_service(service_id, eng_settings,
+            command.rc_settings, meta, metrics, std::move(capabilities));
     } catch (std::system_error &e) {
         // TODO: logging should happen at WAF impl
         DD_STDLOG(DD_STDLOG_RULES_FILE_NOT_FOUND,

--- a/src/helper/service.cpp
+++ b/src/helper/service.cpp
@@ -40,7 +40,8 @@ service::ptr service::from_settings(const service_identifier &id,
     const dds::engine_settings &eng_settings,
     const remote_config::settings &rc_settings,
     std::map<std::string_view, std::string> &meta,
-    std::map<std::string_view, double> &metrics)
+    std::map<std::string_view, double> &metrics,
+    std::vector<remote_config::protocol::capabilities_e> &&capabilities)
 {
     auto engine_ptr = engine::from_settings(eng_settings, meta, metrics);
 
@@ -55,10 +56,6 @@ service::ptr service::from_settings(const service_identifier &id,
     std::vector<remote_config::product> products = {
         {"ASM_FEATURES", asm_features_listener},
         {"ASM_DATA", asm_data_listener}};
-    std::vector<remote_config::protocol::capabilities_e> capabilities = {
-        remote_config::protocol::capabilities_e::ASM_ACTIVATION,
-        remote_config::protocol::capabilities_e::ASM_IP_BLOCKING,
-    };
 
     auto rc_client = remote_config::client::from_settings(
         id, rc_settings, std::move(products), std::move(capabilities));

--- a/src/helper/service.hpp
+++ b/src/helper/service.hpp
@@ -42,7 +42,8 @@ public:
         const dds::engine_settings &eng_settings,
         const remote_config::settings &rc_settings,
         std::map<std::string_view, std::string> &meta,
-        std::map<std::string_view, double> &metrics);
+        std::map<std::string_view, double> &metrics,
+        std::vector<remote_config::protocol::capabilities_e> &&capabilities);
 
     [[nodiscard]] std::shared_ptr<engine> get_engine() const
     {

--- a/src/helper/service_manager.cpp
+++ b/src/helper/service_manager.cpp
@@ -11,7 +11,8 @@ std::shared_ptr<service> service_manager::create_service(
     const service_identifier &id, const engine_settings &settings,
     const remote_config::settings &rc_settings,
     std::map<std::string_view, std::string> &meta,
-    std::map<std::string_view, double> &metrics)
+    std::map<std::string_view, double> &metrics,
+    std::vector<remote_config::protocol::capabilities_e> &&capabilities)
 {
     const std::lock_guard guard{mutex_};
 
@@ -23,8 +24,8 @@ std::shared_ptr<service> service_manager::create_service(
         }
     }
 
-    auto service_ptr =
-        service::from_settings(id, settings, rc_settings, meta, metrics);
+    auto service_ptr = service::from_settings(
+        id, settings, rc_settings, meta, metrics, std::move(capabilities));
     cache_.emplace(id, std::move(service_ptr));
     last_service_ = service_ptr;
 

--- a/src/helper/service_manager.hpp
+++ b/src/helper/service_manager.hpp
@@ -23,11 +23,12 @@ class service_manager {
 public:
     service_manager() = default;
 
-    std::shared_ptr<service> create_service(const service_identifier &id,
-        const engine_settings &settings,
+    virtual std::shared_ptr<service> create_service(
+        const service_identifier &id, const engine_settings &settings,
         const remote_config::settings &rc_settings,
         std::map<std::string_view, std::string> &meta,
-        std::map<std::string_view, double> &metrics);
+        std::map<std::string_view, double> &metrics,
+        std::vector<remote_config::protocol::capabilities_e> &&capabilities);
 
 protected:
     using cache_t = std::unordered_map<service_identifier,

--- a/tests/helper/service_manager_test.cpp
+++ b/tests/helper/service_manager_test.cpp
@@ -31,12 +31,12 @@ TEST(ServiceManagerTest, LoadRulesOK)
     service_identifier sid{"service", "env", "", "", ""};
     service_manager_exp manager;
     auto fn = create_sample_rules_ok();
-    auto service = manager.create_service(sid, {fn, 42}, {}, meta, metrics);
+    auto service = manager.create_service(sid, {fn, 42}, {}, meta, metrics, {});
     EXPECT_EQ(manager.get_cache().size(), 1);
     EXPECT_EQ(metrics[tag::event_rules_loaded], 3);
 
     // loading again should take from the cache
-    auto service2 = manager.create_service(sid, {fn, 42}, {}, meta, metrics);
+    auto service2 = manager.create_service(sid, {fn, 42}, {}, meta, metrics, {});
     EXPECT_EQ(manager.get_cache().size(), 1);
 
     // destroying the services should expire the cache ptr
@@ -53,12 +53,12 @@ TEST(ServiceManagerTest, LoadRulesOK)
 
     // loading another service should cleanup the cache
     service_identifier sid2{"service2", "env"};
-    auto service3 = manager.create_service(sid2, {fn, 42}, {}, meta, metrics);
+    auto service3 = manager.create_service(sid2, {fn, 42}, {}, meta, metrics, {});
     ASSERT_TRUE(weak_ptr.expired());
     EXPECT_EQ(manager.get_cache().size(), 1);
 
     // another service identifier should result in another service
-    auto service4 = manager.create_service(sid, {fn, 42}, {}, meta, metrics);
+    auto service4 = manager.create_service(sid, {fn, 42}, {}, meta, metrics, {});
     EXPECT_EQ(manager.get_cache().size(), 2);
 }
 
@@ -71,7 +71,7 @@ TEST(ServiceManagerTest, LoadRulesFileNotFound)
     EXPECT_THROW(
         {
             manager.create_service({"s", "e"},
-                {"/file/that/does/not/exist", 42}, {}, meta, metrics);
+                {"/file/that/does/not/exist", 42}, {}, meta, metrics, {});
         },
         std::runtime_error);
 }
@@ -84,7 +84,7 @@ TEST(ServiceManagerTest, BadRulesFile)
     EXPECT_THROW(
         {
             manager.create_service(
-                {"s", "e"}, {"/dev/null", 42}, {}, meta, metrics);
+                {"s", "e"}, {"/dev/null", 42}, {}, meta, metrics, {});
         },
         dds::parsing_error);
 }


### PR DESCRIPTION
### Description

When client enables appsec by configuration, it is not necessary to request for this capability as it will be ignored

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


