### PR TITLE
Serialize tracer only when blocking from startup

### DIFF
--- a/src/extension/request_abort.c
+++ b/src/extension/request_abort.c
@@ -317,9 +317,9 @@ static void _emit_error(const char *format, ...)
             dd_appsec_rshutdown();
             DDAPPSEC_G(skip_rshutdown) = true;
         }
-    }
 
-    dd_trace_close_all_spans_and_flush();
+        dd_trace_close_all_spans_and_flush();
+    }
 
     if ((PG(during_request_startup) &&
             strcmp(sapi_module.name, "fpm-fcgi") == 0)) {

--- a/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
+++ b/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
@@ -117,33 +117,6 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
         trace
     }
 
-    @CompileStatic(TypeCheckingMode.SKIP)
-    Object tracesFromRequest(String uri,
-                             @ClosureParams(value = FromAbstractTypeMethods,
-                                    options = ['java.net.HttpURLConnection'])
-                                    Closure<Void> doWithConn = null) {
-        BigInteger traceId = new BigInteger(64, RAND)
-        HttpURLConnection conn = createRequest(uri)
-        conn.useCaches = false
-        conn.addRequestProperty('x-datadog-trace-id', traceId as String)
-        if (doWithConn) {
-            doWithConn.call(conn)
-        }
-        if (conn.doOutput) {
-            conn.outputStream.close()
-        }
-        (conn.errorStream ?: conn.inputStream).close()
-
-        Object trace = nextCapturedTrace()
-
-        def gottenTraceId = ((Map)trace[0][0]).get('trace_id')
-        if (gottenTraceId != traceId) {
-            throw new AssertionError("Mismatched trace id gotten after request to $uri: " +
-                    "expected $traceId, but got $gottenTraceId")
-        }
-        trace
-    }
-
     private void processOptions(Map options) {
         String phpVersion = options['phpVersion']
         String phpVariant = options['phpVariant']

--- a/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
+++ b/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
@@ -157,16 +157,14 @@ trait CommonTests {
 
     @Test
     void 'user blocking'() {
-        def trace = container.tracesFromRequest('/user_id.php?id=user2020') { HttpURLConnection conn ->
+        def trace = container.traceFromRequest('/user_id.php?id=user2020') { HttpURLConnection conn ->
             assert conn.responseCode == 403
 
             def content = (conn.errorStream ?: conn.inputStream).text
             assert content.contains('blocked')
         }
 
-        assert trace[0][0].meta."appsec.blocked" == "true"
-
-        trace = trace[1][0]
+        assert trace.meta."appsec.blocked" == "true"
         assert trace.metrics."_dd.appsec.enabled" == 1.0d
         assert trace.metrics."_dd.appsec.waf.duration" > 0.0d
         assert trace.meta."_dd.appsec.event_rules.version" != ''
@@ -174,16 +172,14 @@ trait CommonTests {
 
     @Test
     void 'user login success blocking'() {
-        def trace = container.tracesFromRequest('/user_login_success.php?id=user2020') { HttpURLConnection conn ->
+        def trace = container.traceFromRequest('/user_login_success.php?id=user2020') { HttpURLConnection conn ->
             assert conn.responseCode == 403
 
             def content = (conn.errorStream ?: conn.inputStream).text
             assert content.contains('blocked')
         }
 
-        assert trace[0][0].meta."appsec.blocked" == "true"
-
-        trace = trace[1][0]
+        assert trace.meta."appsec.blocked" == "true"
         assert trace.metrics."_dd.appsec.enabled" == 1.0d
         assert trace.metrics."_dd.appsec.waf.duration" > 0.0d
         assert trace.meta."_dd.appsec.event_rules.version" != ''
@@ -191,14 +187,12 @@ trait CommonTests {
 
     @Test
     void 'user redirecting'() {
-        def trace = container.tracesFromRequest('/user_id.php?id=user2023') { HttpURLConnection conn ->
+        def trace = container.traceFromRequest('/user_id.php?id=user2023') { HttpURLConnection conn ->
             conn.setInstanceFollowRedirects(false)
             assert conn.responseCode == 303
         }
 
-        assert trace[0][0].meta."appsec.blocked" == "true"
-
-        trace = trace[1][0]
+        assert trace,meta."appsec.blocked" == "true"
         assert trace.metrics."_dd.appsec.enabled" == 1.0d
         assert trace.metrics."_dd.appsec.waf.duration" > 0.0d
         assert trace.meta."_dd.appsec.event_rules.version" != ''
@@ -206,14 +200,12 @@ trait CommonTests {
 
     @Test
     void 'user login success redirecting'() {
-        def trace = container.tracesFromRequest('/user_login_success.php?id=user2023') { HttpURLConnection conn ->
+        def trace = container.traceFromRequest('/user_login_success.php?id=user2023') { HttpURLConnection conn ->
             conn.setInstanceFollowRedirects(false)
             assert conn.responseCode == 303
         }
 
-        assert trace[0][0].meta."appsec.blocked" == "true"
-
-        trace = trace[1][0]
+        assert trace.meta."appsec.blocked" == "true"
         assert trace.metrics."_dd.appsec.enabled" == 1.0d
         assert trace.metrics."_dd.appsec.waf.duration" > 0.0d
         assert trace.meta."_dd.appsec.event_rules.version" != ''


### PR DESCRIPTION
### Description

Currently, the request abort phase follows, amongst many others, the following steps:

- If during request startup, call the ddappsec `RSHUTDOWN`
- Flush the tracer
- If during request startup, call all `RSHUTDOWN` functions, skipping ddappsec.

This is correct when blocking within request startup since the tracer explicitly skips `RSHUTDOWN` during the request startup phase. 

However, user blocking is only done after request startup, so the tracer is flushed before the ddappsec `RSHUTDOWN` is called, at which point we create a new trace to add the relevant tags, which is then flushed by the tracer again during its own `RSHUTDOWN`.

This change ensures we only flush the tracer during startup and it also fixes the integration tests.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


