### PR TITLE
Flush socket on body limit

### DIFF
--- a/src/extension/network.c
+++ b/src/extension/network.c
@@ -157,6 +157,7 @@ dd_result dd_conn_sendv(dd_conn *nonnull conn, zend_llist *nonnull iovecs)
     ssize_t sent_bytes = writev(conn->socket, iovs, (int)iovecs_count + 1);
     efree(iovs);
     if (sent_bytes == -1) {
+        // TODO: Check for EAGAIN
         mlog_err(dd_log_info, "Error writing %zu bytes to helper", total);
         return dd_network;
     }

--- a/src/helper/client.cpp
+++ b/src/helper/client.cpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <mutex>
 #include <spdlog/spdlog.h>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -73,33 +74,53 @@ bool handle_message(client &client, const network::base_broker &broker,
     }
 
     bool send_error = false;
+    bool result = true;
     try {
         auto msg = broker.recv(initial_timeout);
         return maybe_exec_cmd_M<Ms...>(client, msg);
     } catch (const client_disconnect &) {
         SPDLOG_INFO("Client has disconnected");
-    } catch (const std::length_error &e) {
+        // When this exception has been received, we should stop hadling this
+        // particular client.
+        result = false;
+    } catch (const std::out_of_range &e) {
+        // The message received was too large, in theory this should've been
+        // flushed and we can continue handling messages from this client,
+        // however we need to report an error to ensure the client is in a good
+        // state.
         SPDLOG_WARN("Failed to handle message: {}", e.what());
         send_error = true;
+    } catch (const std::length_error &e) {
+        // The message was partially received, the state of the socket is
+        // undefined so we need to respond with an error and stop handling
+        // this client.
+        SPDLOG_WARN("Failed to handle message: {}", e.what());
+        send_error = true;
+        result = false;
     } catch (const bad_cast &e) {
+        // The data received was somehow incomprehensible but we might still be
+        // able to continue, so we only send an error.
         SPDLOG_WARN("Failed to handle message: {}", e.what());
         send_error = true;
     } catch (const msgpack::unpack_error &e) {
+        // The data received was somehow incomprehensible or perhaps beyond
+        // limits, but we might still be able to continue, so we only send an
+        // error.
         SPDLOG_WARN("Failed to unpack message: {}", e.what());
         send_error = true;
     } catch (const std::exception &e) {
         SPDLOG_WARN("Failed to handle message: {}", e.what());
+        result = false;
     }
 
     if (send_error) {
         // This can happen due to a valid error, let's continue handling
         // the client as this might just happen spuriously.
         send_error_response(broker);
-        return true;
     }
 
     // If we reach this point, there was a problem handling the message
-    return false;
+    return result;
 }
 
 } // namespace

--- a/src/helper/network/socket.cpp
+++ b/src/helper/network/socket.cpp
@@ -45,6 +45,23 @@ std::size_t socket::send(const char *buffer, std::size_t len)
     return res;
 }
 
+std::size_t socket::discard(std::size_t len)
+{
+    constexpr auto max_size = std::numeric_limits<uint16_t>::max();
+    std::array<char, max_size> buffer{};
+
+    std::size_t total_size = 0;
+    while (total_size < len) {
+        auto read_size = std::min<std::size_t>(len - total_size, max_size);
+        ssize_t const res = ::recv(sock_, buffer.data(), read_size, 0);
+        if (res <= 0) {
+            break;
+        }
+        total_size += res;
+    }
+    return total_size;
+}
+
 namespace {
 struct timeval from_chrono(std::chrono::milliseconds duration)
 {

--- a/src/helper/network/socket.hpp
+++ b/src/helper/network/socket.hpp
@@ -27,6 +27,7 @@ public:
 
     virtual std::size_t recv(char *buffer, std::size_t len) = 0;
     virtual std::size_t send(const char *buffer, std::size_t len) = 0;
+    virtual std::size_t discard(std::size_t len) = 0;
 
     virtual void set_send_timeout(std::chrono::milliseconds timeout) = 0;
     virtual void set_recv_timeout(std::chrono::milliseconds timeout) = 0;
@@ -58,6 +59,7 @@ public:
 
     std::size_t recv(char *buffer, std::size_t len) override;
     std::size_t send(const char *buffer, std::size_t len) override;
+    std::size_t discard(std::size_t len) override;
 
     void set_send_timeout(std::chrono::milliseconds timeout) override;
     void set_recv_timeout(std::chrono::milliseconds timeout) override;


### PR DESCRIPTION
### Description

At some point the code was refactored and non-critical errors in the communication were introduced, however the body limit error was considered to be non-critical, however it left the socket in an undefined state which then resulted in a cascade of small errors. This PR introduces a fix to ensure errors that leave the socket in an undefined state close the connection and that the body limit exceeded error is handled by flushing the socket of the message body.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


