### PR TITLE
Add test to ensure path parser does not count on /config ending

### DIFF
--- a/tests/helper/remote_config/client_test.cpp
+++ b/tests/helper/remote_config/client_test.cpp
@@ -526,7 +526,7 @@ TEST(ClientConfig, ItGetGeneratedFromString)
     EXPECT_EQ("2.test1.config", cp.id);
 
     cp = remote_config::config_path::from_path(
-        "datadog/55/APM_SAMPLING/dynamic_rates/config");
+        "datadog/55/APM_SAMPLING/dynamic_rates/something");
     EXPECT_EQ(apm_sampling, cp.product);
     EXPECT_EQ("dynamic_rates", cp.id);
 }


### PR DESCRIPTION
### Description

Remote configuration documentation was a bit confusing on wether or not paths had to end on `/config`. In some other languages, path were expected like that. However, it's been clarified that paths don't have to come with `/config` at the end. This PR just modify one unit tests to ensure this is not the case in php

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


