### PR TITLE
Set appsec disabled when ddtrace is not enabled

### DIFF
--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -427,8 +427,11 @@ __thread void *unspecnull TSRMLS_CACHE = NULL;
 
 static void _check_enabled()
 {
-    if ((strcmp(sapi_module.name, "cli") == 0 || sapi_module.phpinfo_as_text) &&
-        !get_global_DD_APPSEC_TESTING()) {
+    if (!dd_trace_is_loaded() && !get_global_DD_APPSEC_TESTING()) {
+        DDAPPSEC_G(enabled_by_configuration) = DISABLED;
+    } else if ((strcmp(sapi_module.name, "cli") == 0 ||
+                   sapi_module.phpinfo_as_text) &&
+               !get_global_DD_APPSEC_TESTING()) {
         DDAPPSEC_G(enabled_by_configuration) = DISABLED;
     } else if (!dd_is_config_using_default(DDAPPSEC_CONFIG_DD_APPSEC_ENABLED)) {
         DDAPPSEC_G(enabled_by_configuration) =

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -427,11 +427,9 @@ __thread void *unspecnull TSRMLS_CACHE = NULL;
 
 static void _check_enabled()
 {
-    if (!dd_trace_is_loaded() && !get_global_DD_APPSEC_TESTING()) {
-        DDAPPSEC_G(enabled_by_configuration) = DISABLED;
-    } else if ((strcmp(sapi_module.name, "cli") == 0 ||
-                   sapi_module.phpinfo_as_text) &&
-               !get_global_DD_APPSEC_TESTING()) {
+    if (!get_global_DD_APPSEC_TESTING() &&
+        (!dd_trace_is_loaded() || strcmp(sapi_module.name, "cli") == 0 ||
+            sapi_module.phpinfo_as_text)) {
         DDAPPSEC_G(enabled_by_configuration) = DISABLED;
     } else if (!dd_is_config_using_default(DDAPPSEC_CONFIG_DD_APPSEC_ENABLED)) {
         DDAPPSEC_G(enabled_by_configuration) =

--- a/src/extension/ddtrace.c
+++ b/src/extension/ddtrace.c
@@ -18,7 +18,8 @@
 static int (*_orig_ddtrace_shutdown)(SHUTDOWN_FUNC_ARGS);
 static int _mod_type;
 static int _mod_number;
-static const char *_mod_version = NULL;
+static const char *_mod_version;
+static bool _ddtrace_loaded;
 static zend_string *_ddtrace_root_span_fname;
 static zend_string *_meta_propname;
 static zend_string *_metrics_propname;
@@ -63,6 +64,7 @@ static void dd_trace_load_symbols(void)
 
 void dd_trace_startup()
 {
+    _ddtrace_loaded = false;
     _ddtrace_root_span_fname = zend_string_init_interned(
         LSTRARG("ddtrace\\root_span"), 1 /* permanent */);
     _meta_propname = zend_string_init_interned(LSTRARG("meta"), 1);
@@ -80,6 +82,7 @@ void dd_trace_startup()
     _mod_type = mod->type;
     _mod_number = mod->module_number;
     _mod_version = mod->version;
+    _ddtrace_loaded = true;
 
     dd_trace_load_symbols();
 
@@ -121,7 +124,7 @@ static int _ddtrace_rshutdown_testing(SHUTDOWN_FUNC_ARGS)
 
 const char *nullable dd_trace_version() { return _mod_version; }
 
-bool dd_trace_is_loaded() { return _mod_version != NULL; }
+bool dd_trace_is_loaded() { return _ddtrace_loaded; }
 
 bool dd_trace_root_span_add_tag(zend_string *nonnull tag, zval *nonnull value)
 {

--- a/src/extension/ddtrace.c
+++ b/src/extension/ddtrace.c
@@ -18,7 +18,7 @@
 static int (*_orig_ddtrace_shutdown)(SHUTDOWN_FUNC_ARGS);
 static int _mod_type;
 static int _mod_number;
-static const char *_mod_version;
+static const char *_mod_version = NULL;
 static zend_string *_ddtrace_root_span_fname;
 static zend_string *_meta_propname;
 static zend_string *_metrics_propname;
@@ -120,6 +120,8 @@ static int _ddtrace_rshutdown_testing(SHUTDOWN_FUNC_ARGS)
 }
 
 const char *nullable dd_trace_version() { return _mod_version; }
+
+bool dd_trace_is_loaded() { return _mod_version != NULL; }
 
 bool dd_trace_root_span_add_tag(zend_string *nonnull tag, zval *nonnull value)
 {

--- a/src/extension/ddtrace.c
+++ b/src/extension/ddtrace.c
@@ -63,8 +63,6 @@ static void dd_trace_load_symbols(void)
 
 void dd_trace_startup()
 {
-    dd_trace_load_symbols();
-
     _ddtrace_root_span_fname = zend_string_init_interned(
         LSTRARG("ddtrace\\root_span"), 1 /* permanent */);
     _meta_propname = zend_string_init_interned(LSTRARG("meta"), 1);
@@ -82,6 +80,8 @@ void dd_trace_startup()
     _mod_type = mod->type;
     _mod_number = mod->module_number;
     _mod_version = mod->version;
+
+    dd_trace_load_symbols();
 
     if (get_global_DD_APPSEC_TESTING()) {
         _orig_ddtrace_shutdown = mod->request_shutdown_func;

--- a/src/extension/ddtrace.h
+++ b/src/extension/ddtrace.h
@@ -1,8 +1,8 @@
 // Unless explicitly stated otherwise all files in this repository are
 // dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
 //
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2021 Datadog, Inc.
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 #pragma once
 
 #include "attributes.h"
@@ -16,6 +16,7 @@ void dd_trace_shutdown(void);
 
 // Returns the tracer version
 const char *nullable dd_trace_version(void);
+bool dd_trace_is_loaded();
 
 // increases the refcount of tag, but not value (like zval_hash_add)
 // however, it destroy value if the operation fails (unlike zval_hash_add)

--- a/src/extension/ddtrace.h
+++ b/src/extension/ddtrace.h
@@ -16,7 +16,7 @@ void dd_trace_shutdown(void);
 
 // Returns the tracer version
 const char *nullable dd_trace_version(void);
-bool dd_trace_is_loaded();
+bool dd_trace_is_loaded(void);
 
 // increases the refcount of tag, but not value (like zval_hash_add)
 // however, it destroy value if the operation fails (unlike zval_hash_add)

--- a/src/extension/tags.c
+++ b/src/extension/tags.c
@@ -770,6 +770,11 @@ static void _add_custom_event_metadata(zend_array *nonnull meta_ht,
 static PHP_FUNCTION(datadog_appsec_track_user_login_success_event)
 {
     UNUSED(return_value);
+    if (DDAPPSEC_G(enabled) != ENABLED) {
+        mlog(dd_log_debug, "Trying to access to track_user_login_success_event "
+                           "function while appsec is disabled");
+        return;
+    }
 
     zend_string *user_id = NULL;
     HashTable *metadata = NULL;
@@ -810,6 +815,11 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_success_event)
 static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event)
 {
     UNUSED(return_value);
+    if (DDAPPSEC_G(enabled) != ENABLED) {
+        mlog(dd_log_debug, "Trying to access to track_user_login_failure_event "
+                           "function while appsec is disabled");
+        return;
+    }
 
     zend_string *user_id = NULL;
     zend_bool exists = false;
@@ -854,6 +864,11 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event)
 static PHP_FUNCTION(datadog_appsec_track_custom_event)
 {
     UNUSED(return_value);
+    if (DDAPPSEC_G(enabled) != ENABLED) {
+        mlog(dd_log_debug, "Trying to access to track_custom_event "
+                           "function while appsec is disabled");
+        return;
+    }
 
     zend_string *event_name = NULL;
     HashTable *metadata = NULL;

--- a/src/extension/user_tracking.c
+++ b/src/extension/user_tracking.c
@@ -7,6 +7,7 @@
 #include "user_tracking.h"
 #include "commands/request_exec.h"
 #include "ddappsec.h"
+#include "ddtrace.h"
 #include "helper_process.h"
 #include "logging.h"
 #include "php_compat.h"
@@ -42,6 +43,9 @@ static PHP_FUNCTION(set_user_wrapper)
 
 void dd_user_tracking_startup(void)
 {
+    if (!dd_trace_is_loaded()) {
+        return;
+    }
     zend_function *set_user = zend_hash_str_find_ptr(
         CG(function_table), LSTRARG("ddtrace\\set_user"));
     if (set_user != NULL) {

--- a/tests/extension/ddtrace_disabled.phpt
+++ b/tests/extension/ddtrace_disabled.phpt
@@ -1,0 +1,14 @@
+--TEST--
+When  ddtrace module no loaded, appsec is disabled
+--INI--
+datadog.appsec.log_file=/tmp/php_appsec_test.log
+datadog.appsec.log_level=debug
+datadog.appsec.testing=0
+--ENV--
+DD_APPSEC_ENABLED=1
+--FILE--
+<?php
+var_dump(\datadog\appsec\is_enabled());
+?>
+--EXPECTF--
+bool(false)

--- a/tests/extension/req_abort_from_user_login_success_event.phpt
+++ b/tests/extension/req_abort_from_user_login_success_event.phpt
@@ -2,6 +2,8 @@
 Track a user login success event and verify the tags in the root span
 --INI--
 extension=ddtrace.so
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_custom_event.phpt
+++ b/tests/extension/track_custom_event.phpt
@@ -2,6 +2,8 @@
 Track a custom event and verify the contents of the root span
 --INI--
 extension=ddtrace.so
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_custom_event_empty_event.phpt
+++ b/tests/extension/track_custom_event_empty_event.phpt
@@ -4,6 +4,8 @@ Track a custom event with an empty event name and verify the logs
 extension=ddtrace.so
 datadog.appsec.log_file=/tmp/php_appsec_test.log
 datadog.appsec.log_level=debug
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_custom_event_no_root_span.phpt
+++ b/tests/extension/track_custom_event_no_root_span.phpt
@@ -6,6 +6,7 @@ datadog.appsec.log_file=/tmp/php_appsec_test.log
 datadog.appsec.log_level=debug
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_user_login_failure_event.phpt
+++ b/tests/extension/track_user_login_failure_event.phpt
@@ -2,6 +2,8 @@
 Track a user login failure event and verify the tags in the root span
 --INI--
 extension=ddtrace.so
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_user_login_failure_event_empty_user.phpt
+++ b/tests/extension/track_user_login_failure_event_empty_user.phpt
@@ -4,6 +4,8 @@ Track a user login failure event with an empty user id and verify the logs
 extension=ddtrace.so
 datadog.appsec.log_file=/tmp/php_appsec_test.log
 datadog.appsec.log_level=debug
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_user_login_failure_event_existing_user.phpt
+++ b/tests/extension/track_user_login_failure_event_existing_user.phpt
@@ -2,6 +2,8 @@
 Track a user login failure event and verify the tags in the root span
 --INI--
 extension=ddtrace.so
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_user_login_failure_event_no_root_span.phpt
+++ b/tests/extension/track_user_login_failure_event_no_root_span.phpt
@@ -6,6 +6,7 @@ datadog.appsec.log_file=/tmp/php_appsec_test.log
 datadog.appsec.log_level=debug
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_user_login_success_event.phpt
+++ b/tests/extension/track_user_login_success_event.phpt
@@ -2,6 +2,8 @@
 Track a user login success event and verify the tags in the root span
 --INI--
 extension=ddtrace.so
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_user_login_success_event_empty_user.phpt
+++ b/tests/extension/track_user_login_success_event_empty_user.phpt
@@ -4,6 +4,8 @@ Track a user login success event with an empty user id and verify the logs
 extension=ddtrace.so
 datadog.appsec.log_file=/tmp/php_appsec_test.log
 datadog.appsec.log_level=debug
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/track_user_login_success_event_no_root_span.phpt
+++ b/tests/extension/track_user_login_success_event_no_root_span.phpt
@@ -6,6 +6,7 @@ datadog.appsec.log_file=/tmp/php_appsec_test.log
 datadog.appsec.log_level=debug
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/tracking_functions_disabled_01.phpt
+++ b/tests/extension/tracking_functions_disabled_01.phpt
@@ -1,0 +1,48 @@
+--TEST--
+When  ddtrace module no loaded, functions do nothing
+--INI--
+datadog.appsec.log_file=/tmp/php_appsec_test.log
+datadog.appsec.log_level=debug
+--FILE--
+<?php
+require __DIR__ . '/inc/logging.php';
+
+use function datadog\appsec\track_custom_event;
+use function datadog\appsec\track_user_login_success_event;
+use function datadog\appsec\track_user_login_failure_event;
+
+
+var_dump(track_user_login_success_event("Admin",
+[
+    "value" => "something",
+    "metadata" => "some other metadata",
+    "email" => "noneofyour@business.com"
+]));
+
+var_dump(track_user_login_failure_event("Admin", false,
+[
+    "value" => "something",
+    "metadata" => "some other metadata",
+    "email" => "noneofyour@business.com"
+]));
+
+var_dump(track_custom_event("myevent",
+[
+    "value" => "something",
+    "metadata" => "some other metadata",
+    "email" => "noneofyour@business.com"
+]));
+
+
+match_log("/Trying to access to track_user_login_success_event function while appsec is disabled/");
+match_log("/Trying to access to track_user_login_failure_event function while appsec is disabled/");
+match_log("/Trying to access to track_custom_event function while appsec is disabled/");
+
+?>
+--EXPECTF--
+NULL
+NULL
+NULL
+found message in log matching /Trying to access to track_user_login_success_event function while appsec is disabled/
+found message in log matching /Trying to access to track_user_login_failure_event function while appsec is disabled/
+found message in log matching /Trying to access to track_custom_event function while appsec is disabled/

--- a/tests/extension/user_tracking_block_from_login_success.phpt
+++ b/tests/extension/user_tracking_block_from_login_success.phpt
@@ -2,6 +2,8 @@
 Block from a user login success event
 --INI--
 extension=ddtrace.so
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/user_tracking_do_nothing_from_login_success.phpt
+++ b/tests/extension/user_tracking_do_nothing_from_login_success.phpt
@@ -2,6 +2,8 @@
 Don't block or redirect from user login success event
 --INI--
 extension=ddtrace.so
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;

--- a/tests/extension/user_tracking_redirect_from_login_success.phpt
+++ b/tests/extension/user_tracking_redirect_from_login_success.phpt
@@ -2,6 +2,8 @@
 Redirect from a user login success event
 --INI--
 extension=ddtrace.so
+--ENV--
+DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;


### PR DESCRIPTION
### Description

There are cases that customers disabled ddtrace but not appsec. On those cases we don't want appsec extension to be enabled.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


