### PR TITLE
Upgrade WAF to 1.10.0 and add custom_rules capability

### DIFF
--- a/src/helper/remote_config/listeners/engine_listener.hpp
+++ b/src/helper/remote_config/listeners/engine_listener.hpp
@@ -10,6 +10,7 @@
 #include "engine.hpp"
 #include "listener.hpp"
 #include "parameter.hpp"
+#include "remote_config/protocol/client.hpp"
 #include <optional>
 #include <rapidjson/document.h>
 #include <utility>
@@ -40,7 +41,8 @@ public:
                     protocol::capabilities_e::ASM_EXCLUSIONS |
                         protocol::capabilities_e::ASM_CUSTOM_BLOCKING_RESPONSE |
                         protocol::capabilities_e::ASM_REQUEST_BLOCKING |
-                        protocol::capabilities_e::ASM_RESPONSE_BLOCKING},
+                        protocol::capabilities_e::ASM_RESPONSE_BLOCKING |
+                        protocol::capabilities_e::ASM_CUSTOM_RULES},
             {asm_dd_product, protocol::capabilities_e::ASM_DD_RULES},
             {asm_data_product,
                 protocol::capabilities_e::ASM_IP_BLOCKING |

--- a/tests/helper/client_test.cpp
+++ b/tests/helper/client_test.cpp
@@ -113,7 +113,7 @@ TEST(ClientTest, ClientInit)
 
     EXPECT_STREQ(msg_res->status.c_str(), "ok");
     EXPECT_EQ(msg_res->meta.size(), 2);
-    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.9.0");
+    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.10.0");
     EXPECT_STREQ(msg_res->meta[tag::event_rules_errors].c_str(), "{}");
 
     EXPECT_EQ(msg_res->metrics.size(), 2);
@@ -152,7 +152,7 @@ TEST(ClientTest, ClientInitInvalidRules)
 
     EXPECT_STREQ(msg_res->status.c_str(), "ok");
     EXPECT_EQ(msg_res->meta.size(), 2);
-    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.9.0");
+    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.10.0");
 
     rapidjson::Document doc;
     doc.Parse(msg_res->meta[tag::event_rules_errors]);

--- a/tests/helper/waf_test.cpp
+++ b/tests/helper/waf_test.cpp
@@ -50,7 +50,7 @@ TEST(WafTest, InitWithInvalidRules)
         waf::instance::from_settings(cs, ruleset, meta, metrics)};
 
     EXPECT_EQ(meta.size(), 2);
-    EXPECT_STREQ(meta[tag::waf_version].c_str(), "1.9.0");
+    EXPECT_STREQ(meta[tag::waf_version].c_str(), "1.10.0");
 
     rapidjson::Document doc;
     doc.Parse(meta[tag::event_rules_errors]);


### PR DESCRIPTION
### Description

- Upgrade WAF to 1.10.0
- Add missing `CUSTOM_RULES` capability to engine listener.
### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


