### PR TITLE
Avoid emitting errors when blocking on RSHUTDOWN

### DIFF
--- a/src/extension/ddappsec.h
+++ b/src/extension/ddappsec.h
@@ -29,6 +29,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddappsec)
     //Defines enablement status computed taking into account enabled_by_configuration and remote config
     enabled_configuration enabled;
     bool skip_rshutdown;
+    bool during_request_shutdown;
 ZEND_END_MODULE_GLOBALS(ddappsec)
 // clang-format on
 

--- a/src/extension/request_abort.c
+++ b/src/extension/request_abort.c
@@ -308,6 +308,12 @@ static void _suppress_error_reporting(void);
 ATTR_FORMAT(1, 2)
 static void _emit_error(const char *format, ...)
 {
+    if (DDAPPSEC_G(during_request_shutdown)) {
+        // Avoid emitting errors during request shutdown, this can cause other
+        // extensions with zend error handlers to misbehave
+        return;
+    }
+
     va_list args;
 
     va_start(args, format);

--- a/tests/extension/req_abort_from_rshutdown_auto.phpt
+++ b/tests/extension/req_abort_from_rshutdown_auto.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/mock_helper.php';
 $helper = Helper::createInitedRun([
     response_list(response_request_init(['record', new ArrayObject(), ['{"found":"attack"}','{"another":"attack"}']])),
     response_list(response_request_shutdown(['block', new ArrayObject(), ['{"yet another":"attack"}']]))
-], ['continuous' => true]);
+], ['continuous' => false]);
 
 rinit();
 $helper->get_commands(); //ignore
@@ -24,4 +24,3 @@ Status: 403 Forbidden
 Content-type: application/json
 --EXPECTF--
 {"errors": [{"title": "You've been blocked", "detail": "Sorry, you cannot access this page. Please contact the customer service team. Security provided by Datadog."}]}
-Warning: datadog\appsec\testing\rshutdown(): Datadog blocked the request and presented a static error page in %s on line %d

--- a/tests/extension/req_abort_from_rshutdown_html_500.phpt
+++ b/tests/extension/req_abort_from_rshutdown_html_500.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/mock_helper.php';
 $helper = Helper::createInitedRun([
     response_list(response_request_init(['record', new ArrayObject(), ['{"found":"attack"}','{"another":"attack"}']])),
     response_list(response_request_shutdown(['block', ['status_code' => "500", 'type' => 'html', 'unused' => 'value'], ['{"yet another":"attack"}']]))
-], ['continuous' => true]);
+], ['continuous' => false]);
 
 rinit();
 $helper->get_commands(); //ignore
@@ -24,4 +24,3 @@ Status: 500 Internal Server Error
 Content-type: text/html;charset=UTF-8
 --EXPECTF--
 <!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>You've been blocked</title><style>a,body,div,html,span{margin:0;padding:0;border:0;font-size:100%;font:inherit;vertical-align:baseline}body{background:-webkit-radial-gradient(26% 19%,circle,#fff,#f4f7f9);background:radial-gradient(circle at 26% 19%,#fff,#f4f7f9);display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-ms-flex-line-pack:center;align-content:center;width:100%;min-height:100vh;line-height:1;flex-direction:column}p{display:block}main{text-align:center;flex:1;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-ms-flex-line-pack:center;align-content:center;flex-direction:column}p{font-size:18px;line-height:normal;color:#646464;font-family:sans-serif;font-weight:400}a{color:#4842b7}footer{width:100%;text-align:center}footer p{font-size:16px}</style></head><body><main><p>Sorry, you cannot access this page. Please contact the customer service team.</p></main><footer><p>Security provided by <a href="https://www.datadoghq.com/product/security-platform/application-security-monitoring/" target="_blank">Datadog</a></p></footer></body></html>
-Warning: datadog\appsec\testing\rshutdown(): Datadog blocked the request and presented a static error page in %s on line %d


### PR DESCRIPTION
### Description

Emitting errors on RSHUTDOWN can cause some issues with extensions overriding the zend error callback. On the other hand, emitting errors at this stage also doesn't seem to provide much value.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


