### PR TITLE
Integration: support multiple traces and spans but provide only the root span

### DIFF
--- a/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
+++ b/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
@@ -117,6 +117,33 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
         trace
     }
 
+    @CompileStatic(TypeCheckingMode.SKIP)
+    Object tracesFromRequest(String uri,
+                             @ClosureParams(value = FromAbstractTypeMethods,
+                                    options = ['java.net.HttpURLConnection'])
+                                    Closure<Void> doWithConn = null) {
+        BigInteger traceId = new BigInteger(64, RAND)
+        HttpURLConnection conn = createRequest(uri)
+        conn.useCaches = false
+        conn.addRequestProperty('x-datadog-trace-id', traceId as String)
+        if (doWithConn) {
+            doWithConn.call(conn)
+        }
+        if (conn.doOutput) {
+            conn.outputStream.close()
+        }
+        (conn.errorStream ?: conn.inputStream).close()
+
+        Object trace = nextCapturedTrace()
+
+        def gottenTraceId = ((Map)trace[0][0]).get('trace_id')
+        if (gottenTraceId != traceId) {
+            throw new AssertionError("Mismatched trace id gotten after request to $uri: " +
+                    "expected $traceId, but got $gottenTraceId")
+        }
+        trace
+    }
+
     private void processOptions(Map options) {
         String phpVersion = options['phpVersion']
         String phpVariant = options['phpVariant']

--- a/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
+++ b/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
@@ -106,37 +106,10 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
         (conn.errorStream ?: conn.inputStream).close()
 
         Object trace = nextCapturedTrace()
-        assert trace.size() == 1 && trace[0].size() == 1
+        assert trace.size() >= 1 && trace[0].size() >= 1
         trace = trace[0][0]
 
         def gottenTraceId = ((Map)trace).get('trace_id')
-        if (gottenTraceId != traceId) {
-            throw new AssertionError("Mismatched trace id gotten after request to $uri: " +
-                    "expected $traceId, but got $gottenTraceId")
-        }
-        trace
-    }
-
-    @CompileStatic(TypeCheckingMode.SKIP)
-    Object tracesFromRequest(String uri,
-                             @ClosureParams(value = FromAbstractTypeMethods,
-                                    options = ['java.net.HttpURLConnection'])
-                                    Closure<Void> doWithConn = null) {
-        BigInteger traceId = new BigInteger(64, RAND)
-        HttpURLConnection conn = createRequest(uri)
-        conn.useCaches = false
-        conn.addRequestProperty('x-datadog-trace-id', traceId as String)
-        if (doWithConn) {
-            doWithConn.call(conn)
-        }
-        if (conn.doOutput) {
-            conn.outputStream.close()
-        }
-        (conn.errorStream ?: conn.inputStream).close()
-
-        Object trace = nextCapturedTrace()
-
-        def gottenTraceId = ((Map)trace[0][0]).get('trace_id')
         if (gottenTraceId != traceId) {
             throw new AssertionError("Mismatched trace id gotten after request to $uri: " +
                     "expected $traceId, but got $gottenTraceId")


### PR DESCRIPTION
### Description

Support receiving multiple traces and spans, however since https://github.com/DataDog/dd-appsec-php/pull/273 only the root span is needed so the function still discards the rest.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


