### PR TITLE
Upgrade WAF to 1.14.0

### DIFF
--- a/tests/helper/client_test.cpp
+++ b/tests/helper/client_test.cpp
@@ -126,7 +126,7 @@ TEST(ClientTest, ClientInit)
 
     EXPECT_STREQ(msg_res->status.c_str(), "ok");
     EXPECT_EQ(msg_res->meta.size(), 2);
-    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.13.1");
+    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.14.0");
     EXPECT_STREQ(msg_res->meta[tag::event_rules_errors].c_str(), "{}");
 
     EXPECT_EQ(msg_res->metrics.size(), 2);
@@ -165,7 +165,7 @@ TEST(ClientTest, ClientInitInvalidRules)
 
     EXPECT_STREQ(msg_res->status.c_str(), "ok");
     EXPECT_EQ(msg_res->meta.size(), 2);
-    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.13.1");
+    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.14.0");
 
     rapidjson::Document doc;
     doc.Parse(msg_res->meta[tag::event_rules_errors]);

--- a/tests/helper/waf_test.cpp
+++ b/tests/helper/waf_test.cpp
@@ -50,7 +50,7 @@ TEST(WafTest, InitWithInvalidRules)
         waf::instance::from_settings(cs, ruleset, meta, metrics)};
 
     EXPECT_EQ(meta.size(), 2);
-    EXPECT_STREQ(meta[tag::waf_version].c_str(), "1.13.1");
+    EXPECT_STREQ(meta[tag::waf_version].c_str(), "1.14.0");
 
     rapidjson::Document doc;
     doc.Parse(meta[tag::event_rules_errors]);


### PR DESCRIPTION
### Description

This PR simply updates the version of the WAF to 1.14.0 which is just a drop-in replacement and doesn't require any changes for now. Changes will be required once we start implementing support for schema extraction and classification.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


