### PR TITLE
Upgrade tracer to v0.91.0 and remove master build downloads

### DIFF
--- a/.github/workflows/release/build_package
+++ b/.github/workflows/release/build_package
@@ -18,7 +18,7 @@ function prepare {
     -DDD_APPSEC_BUILD_EXTENSION=$(if [[ $php_v = 'helper' ]]; then echo OFF; else echo ON; fi) \
     -DPHP_CONFIG="${php_v}"/bin/php-config \
     -DDD_APPSEC_BUILD_TRACER=$(if [[ $php_v =~ alpha|beta|RC ]]; then echo ON; else echo OFF; fi) \
-    -DDD_APPSEC_TRACER_VERSION=0.86.2 \
+    -DDD_APPSEC_TRACER_VERSION=0.91.0 \
     -DDD_APPSEC_ENABLE_PATCHELF_LIBC=ON \
     -DDD_APPSEC_INSTALL_RULES_FILE=/project/.github/workflows/release/recommended.json \
     -DCMAKE_TOOLCHAIN_FILE=/build/Toolchain.cmake \

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -68,10 +68,6 @@ jobs:
           name: package
           path: binaries/
 
-      - name: Download tracer
-        run: wget https://output.circle-artifacts.com/output/job/434c6010-da34-4df5-9ce9-1531bb0e60f8/artifacts/0/datadog-php-tracer-0.90.0+36ed038a4beff76c7a4cdeac002a02d4060eaadb.x86_64.tar.gz
-        working-directory: binaries
-
       - name: Remove debug package
         run: |
           ls -la binaries/

--- a/cmake/tracer.cmake
+++ b/cmake/tracer.cmake
@@ -1,5 +1,5 @@
 option(DD_APPSEC_BUILD_TRACER "Whether to build the tracer from source" ON)
-set(DD_APPSEC_TRACER_VERSION "1c4f968595bfd04de4c95f7ad29c74595c47ccb1" CACHE STRING "The tracer version to download")
+set(DD_APPSEC_TRACER_VERSION "0.91.0" CACHE STRING "The tracer version to download")
 
 add_library(tracer SHARED IMPORTED GLOBAL)
 
@@ -41,7 +41,7 @@ if(DD_APPSEC_BUILD_TRACER)
 else()
     include(ExternalProject)
     ExternalProject_Add(proj_tracer
-        URL https://output.circle-artifacts.com/output/job/434c6010-da34-4df5-9ce9-1531bb0e60f8/artifacts/0/datadog-php-tracer-0.90.0+36ed038a4beff76c7a4cdeac002a02d4060eaadb.x86_64.tar.gz
+        URL https://github.com/DataDog/dd-trace-php/releases/download/${DD_APPSEC_TRACER_VERSION}/datadog-php-tracer-${DD_APPSEC_TRACER_VERSION}.x86_64.tar.gz
         PREFIX  proj_tracer_release
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/tests/docker/alpine-apache2-fpm/Dockerfile
+++ b/tests/docker/alpine-apache2-fpm/Dockerfile
@@ -29,6 +29,8 @@ ADD tests/docker/fpm-common/www.conf /etc/php-fpm.d/
 
 RUN mkdir -p /var/log/apache2 /run/apache2
 
+RUN chmod a+rx /root
+
 ENV DD_TRACE_ENABLED=true
 ENV DD_TRACE_GENERATE_ROOT_SPAN=true
 

--- a/tests/docker/alpine-apache2-fpm/Dockerfile
+++ b/tests/docker/alpine-apache2-fpm/Dockerfile
@@ -8,12 +8,8 @@ FROM php:$PHP_VERSION-fpm-alpine$ALPINE_VERSION
 RUN apk add --no-cache apache2 apache2-proxy libexecinfo bash libgcc
 
 ARG TRACER_VERSION
-#RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
-    #PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
-
-RUN curl -Lf -o /tmp/dd-library.tar.gz https://output.circle-artifacts.com/output/job/434c6010-da34-4df5-9ce9-1531bb0e60f8/artifacts/0/datadog-php-tracer-0.90.0+36ed038a4beff76c7a4cdeac002a02d4060eaadb.x86_64.tar.gz && \
-    curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
-    PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --php-bin all --no-appsec --tracer-file /tmp/dd-library.tar.gz
+RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
+    PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
 
 RUN rm -rf /var/www/localhost/htdocs
 ADD --chown=www-data:www-data examples/webroot/ /var/www/localhost/htdocs/

--- a/tests/docker/apache2-fpm/Dockerfile
+++ b/tests/docker/apache2-fpm/Dockerfile
@@ -33,6 +33,8 @@ RUN a2enmod proxy_fcgi
 RUN a2dissite 000-default
 RUN a2ensite php-site
 
+RUN chmod a+rx /root
+
 ENV DD_TRACE_ENABLED=true
 ENV DD_TRACE_GENERATE_ROOT_SPAN=true
 

--- a/tests/docker/apache2-fpm/Dockerfile
+++ b/tests/docker/apache2-fpm/Dockerfile
@@ -9,12 +9,8 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 ARG TRACER_VERSION
-#RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
-    #PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
-
-RUN curl -Lf -o /tmp/dd-library.tar.gz https://output.circle-artifacts.com/output/job/434c6010-da34-4df5-9ce9-1531bb0e60f8/artifacts/0/datadog-php-tracer-0.90.0+36ed038a4beff76c7a4cdeac002a02d4060eaadb.x86_64.tar.gz && \
-    curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
-    PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --php-bin all --no-appsec --tracer-file /tmp/dd-library.tar.gz
+RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
+    PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
 
 RUN rm -rf /var/www/html
 ADD --chown=www-data:www-data examples/webroot/ /var/www/html/

--- a/tests/docker/apache2-mod/Dockerfile
+++ b/tests/docker/apache2-mod/Dockerfile
@@ -9,12 +9,8 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 ARG TRACER_VERSION
-#RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
-    #PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
-
-RUN curl -Lf -o /tmp/dd-library.tar.gz https://output.circle-artifacts.com/output/job/434c6010-da34-4df5-9ce9-1531bb0e60f8/artifacts/0/datadog-php-tracer-0.90.0+36ed038a4beff76c7a4cdeac002a02d4060eaadb.x86_64.tar.gz && \
-    curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
-    PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --php-bin all --no-appsec --tracer-file /tmp/dd-library.tar.gz
+RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
+    PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
 
 #RUN curl -Lf -o /tmp/ddtrace.tar.gz https://github.com/DataDog/dd-trace-php/archive/$TRACER_VERSION.tar.gz && \
 #	mkdir /tmp/ddtrace-build/ && cd /tmp/ddtrace-build && \

--- a/tests/docker/apache2-mod/Dockerfile
+++ b/tests/docker/apache2-mod/Dockerfile
@@ -40,6 +40,8 @@ RUN if echo $VARIANT | grep -q zts; \
 RUN if ! { echo $VARIANT | grep -q zts; }; then a2dismod mpm_event; a2enmod mpm_prefork; fi
 RUN a2enmod php
 
+RUN chmod a+rx /root
+
 ENV DD_TRACE_ENABLED=true
 ENV DD_TRACE_GENERATE_ROOT_SPAN=true
 

--- a/tests/docker/nginx-fpm/Dockerfile
+++ b/tests/docker/nginx-fpm/Dockerfile
@@ -9,12 +9,8 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 ARG TRACER_VERSION
-#RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
-    #PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
-
-RUN curl -Lf -o /tmp/dd-library.tar.gz https://output.circle-artifacts.com/output/job/434c6010-da34-4df5-9ce9-1531bb0e60f8/artifacts/0/datadog-php-tracer-0.90.0+36ed038a4beff76c7a4cdeac002a02d4060eaadb.x86_64.tar.gz && \
-    curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
-    PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --php-bin all --no-appsec --tracer-file /tmp/dd-library.tar.gz
+RUN curl -Lf -o /tmp/dd-library-php-setup.php https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php && \
+    PHP_INI_SCAN_DIR=/etc/php/ php /tmp/dd-library-php-setup.php --no-appsec --tracer-version $TRACER_VERSION --php-bin all
 
 RUN rm -rf /var/www/html
 ADD --chown=www-data:www-data examples/webroot/ /var/www/html/

--- a/tests/integration/build.gradle
+++ b/tests/integration/build.gradle
@@ -49,7 +49,7 @@ testMatrix.each { spec ->
 
         it.systemProperty 'PHP_VERSION', phpVersion
         it.systemProperty 'VARIANT', variant
-        it.systemProperty 'TRACER_VERSION', '0.90.0'
+        it.systemProperty 'TRACER_VERSION', '0.91.0'
     }
 
     tasks['check'].dependsOn task

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -77,12 +77,17 @@ if(DD_APPSEC_BUILD_EXTENSION)
     add_library(Tea::Tea ALIAS Tea)
 
     add_library(tea-libphp INTERFACE)
+    target_compile_options(tea-libphp INTERFACE ${PHP_INCLUDES})
     add_library(Tea::Php ALIAS tea-libphp)
 
     set(ZAI_MODULES json env config)
     add_library(zai_zend_abstract_interface INTERFACE)
     target_include_directories(zai_zend_abstract_interface INTERFACE ${ZAI_INCLUDES})
+
     add_subdirectory(ddtrace/zend_abstract_interface/zai_string)
+    set_target_properties(zai_string PROPERTIES POSITION_INDEPENDENT_CODE 1)
+    target_compile_options(zai_string PRIVATE ${PHP_INCLUDES})
+
     add_subdirectory(ddtrace/zend_abstract_interface/zai_assert)
     foreach(module json env config)
         set(module_name "zai_${module}")


### PR DESCRIPTION
### Description

Due to the breaking changes  (between the tracer and appsec) introduced in https://github.com/DataDog/dd-appsec-php/pull/288, many of the jobs, dockerfiles, cmakes and scripts had to be updated to download specific artifacts from the tracer's CI pipeline. This PR reverts those changes and updates all tracer versions (including submodule) to v0.91.0.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


