### PR TITLE
Fix duplicate runtime ID

### DIFF
--- a/src/helper/remote_config/client.cpp
+++ b/src/helper/remote_config/client.cpp
@@ -32,8 +32,8 @@ client::client(std::unique_ptr<http_api> &&arg_api, service_identifier &&sid,
     remote_config::settings settings,
     std::vector<listener_base::shared_ptr> listeners)
     : api_(std::move(arg_api)), id_(dds::generate_random_uuid()),
-      ids_(sid.runtime_id), sid_(std::move(sid)),
-      settings_(std::move(settings)), listeners_(std::move(listeners))
+      sid_(std::move(sid)), settings_(std::move(settings)),
+      listeners_(std::move(listeners))
 {
     for (auto const &listener : listeners_) {
         const auto &supported_products = listener->get_supported_products();
@@ -213,7 +213,9 @@ bool client::is_remote_config_available()
 
 bool client::poll()
 {
-    if (api_ == nullptr) {
+    // Wait until we have a valid runtime ID, once this ID is available,
+    // it'll always have a value, even if all extensions have disconnected
+    if (api_ == nullptr || !ids_.has_value()) {
         return false;
     }
 

--- a/src/helper/runtime_id_pool.hpp
+++ b/src/helper/runtime_id_pool.hpp
@@ -21,17 +21,7 @@ namespace dds {
  */
 class runtime_id_pool {
 public:
-    explicit runtime_id_pool(const std::string &initial_id)
-    {
-        if (initial_id.empty()) {
-            throw std::invalid_argument(
-                "runtime ID pool initialised with invalid ID");
-        }
-
-        std::lock_guard<std::mutex> lock{mtx_};
-        ids_.emplace(initial_id);
-        current_ = *ids_.begin();
-    }
+    runtime_id_pool() = default;
 
     void add(std::string id)
     {
@@ -73,10 +63,16 @@ public:
         return current_;
     }
 
+    [[nodiscard]] bool has_value() const
+    {
+        std::lock_guard<std::mutex> lock{mtx_};
+        return !current_.empty();
+    }
+
 protected:
     mutable std::mutex mtx_;
     std::unordered_multiset<std::string> ids_;
-    std::string current_;
+    std::string current_{};
 };
 
 } // namespace dds

--- a/tests/helper/remote_config/client_test.cpp
+++ b/tests/helper/remote_config/client_test.cpp
@@ -370,6 +370,7 @@ TEST_F(RemoteConfigClient, OnNetworkApiErrorTheExceptionsFlows)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     try {
         api_client.poll();
@@ -440,10 +441,25 @@ TEST_F(RemoteConfigClient, ItCallsToApiOnPoll)
 
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_EQ(sort_arrays(generate_request_serialized(false, false)),
         sort_arrays(request_sent));
+}
+
+TEST_F(RemoteConfigClient, PollFailsWithoutRuntimeID)
+{
+    auto api = std::make_unique<mock::api>();
+    EXPECT_CALL(*api, get_configs(_)).Times(0);
+
+    service_identifier sid{
+        service, extra_services, env, tracer_version, app_version, runtime_id};
+
+    dds::test_client api_client(
+        id, std::move(api), std::move(sid), std::move(settings), listeners_);
+
+    EXPECT_FALSE(api_client.poll());
 }
 
 TEST_F(RemoteConfigClient, ReplaceRuntimeID)
@@ -460,6 +476,7 @@ TEST_F(RemoteConfigClient, ReplaceRuntimeID)
 
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     // Unregister the old ID and register a new one
     api_client.unregister_runtime_id(runtime_id);
@@ -488,6 +505,7 @@ TEST_F(RemoteConfigClient, RemoveRuntimeID)
 
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     // Unregister the ID, it should still be used
     api_client.unregister_runtime_id(runtime_id);
@@ -503,6 +521,7 @@ TEST_F(RemoteConfigClient, ItReturnErrorWhenApiNotProvided)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, nullptr, std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_FALSE(api_client.poll());
 }
@@ -516,6 +535,7 @@ TEST_F(RemoteConfigClient, ItReturnErrorWhenResponseIsInvalidJson)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_FALSE(api_client.poll());
 }
@@ -535,6 +555,7 @@ TEST_F(RemoteConfigClient,
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     // Validate first request does not contain any error
     EXPECT_FALSE(api_client.poll());
@@ -563,6 +584,7 @@ TEST_F(RemoteConfigClient,
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     // Validate first request does not contain any error
     EXPECT_FALSE(api_client.poll());
@@ -660,6 +682,7 @@ TEST_F(RemoteConfigClient, ItReturnsErrorWhenClientConfigPathCantBeParsed)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     // Validate first request does not contain any error
     EXPECT_FALSE(api_client.poll());
@@ -688,6 +711,7 @@ TEST_F(RemoteConfigClient, ItReturnsErrorIfProductOnPathNotRequested)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings));
+    api_client.register_runtime_id(runtime_id);
 
     // Validate first request does not contain any error
     EXPECT_FALSE(api_client.poll());
@@ -720,6 +744,7 @@ TEST_F(RemoteConfigClient, ItGeneratesClientStateAndCacheFromResponse)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_TRUE(api_client.poll());
@@ -771,6 +796,7 @@ TEST_F(RemoteConfigClient, WhenANewConfigIsAddedItCallsOnUpdateOnPoll)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(id, std::move(api), std::move(sid),
         std::move(settings), {listener01, listener_called_no_configs01});
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
 }
@@ -837,6 +863,7 @@ TEST_F(RemoteConfigClient, WhenAConfigDissapearOnFollowingPollsItCallsToUnApply)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), {listener01});
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_TRUE(api_client.poll());
@@ -941,6 +968,7 @@ TEST_F(
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), {listener01});
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_TRUE(api_client.poll());
@@ -968,6 +996,7 @@ TEST_F(RemoteConfigClient, FilesThatAreInCacheAreUsedWhenNotInTargetFiles)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_TRUE(api_client.poll());
@@ -1002,6 +1031,7 @@ TEST_F(RemoteConfigClient, NotTrackedFilesAreDeletedFromCache)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_TRUE(api_client.poll());
@@ -1092,6 +1122,7 @@ TEST_F(RemoteConfigClient, TestHashIsDifferentFromTheCache)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_FALSE(api_client.poll());
@@ -1176,6 +1207,7 @@ TEST_F(RemoteConfigClient, TestWhenFileGetsFromCacheItsCachedLenUsed)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_TRUE(api_client.poll());
@@ -1223,6 +1255,7 @@ TEST_F(RemoteConfigClient, ProductsWithAListenerAcknowledgeUpdates)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_TRUE(api_client.poll());
@@ -1267,6 +1300,7 @@ TEST_F(RemoteConfigClient, WhenAListerCanProccesAnUpdateTheConfigStateGetsError)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(id, std::move(api), std::move(sid),
         std::move(settings), std::move(listeners));
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
     EXPECT_TRUE(api_client.poll());
@@ -1300,6 +1334,7 @@ TEST_F(RemoteConfigClient, OneClickActivationIsSetAsCapability)
         service, extra_services, env, tracer_version, app_version, runtime_id};
     dds::test_client api_client(
         id, std::move(api), std::move(sid), std::move(settings), listeners_);
+    api_client.register_runtime_id(runtime_id);
 
     EXPECT_TRUE(api_client.poll());
 

--- a/tests/helper/runtime_id_pool_test.cpp
+++ b/tests/helper/runtime_id_pool_test.cpp
@@ -9,15 +9,11 @@
 
 namespace dds {
 
-TEST(RuntimeIDPool, InvalidConstruction)
-{
-    EXPECT_THROW(runtime_id_pool ids{""}, std::invalid_argument);
-}
-
 TEST(RuntimeIDPool, ConstructionAndGet)
 {
     auto uuid = generate_random_uuid();
-    runtime_id_pool ids{uuid};
+    runtime_id_pool ids;
+    ids.add(uuid);
 
     EXPECT_STREQ(ids.get().c_str(), uuid.c_str());
 }
@@ -25,7 +21,8 @@ TEST(RuntimeIDPool, ConstructionAndGet)
 TEST(RuntimeIDPool, AddAndGet)
 {
     auto uuid = generate_random_uuid();
-    runtime_id_pool ids{uuid};
+    runtime_id_pool ids;
+    ids.add(uuid);
 
     ids.add(generate_random_uuid());
 
@@ -35,7 +32,8 @@ TEST(RuntimeIDPool, AddAndGet)
 TEST(RuntimeIDPool, RemoveLast)
 {
     auto uuid = generate_random_uuid();
-    runtime_id_pool ids{uuid};
+    runtime_id_pool ids;
+    ids.add(uuid);
     ids.remove(uuid);
 
     EXPECT_STREQ(ids.get().c_str(), uuid.c_str());
@@ -44,7 +42,8 @@ TEST(RuntimeIDPool, RemoveLast)
 TEST(RuntimeIDPool, RemoveCurrent)
 {
     auto uuid = generate_random_uuid();
-    runtime_id_pool ids{uuid};
+    runtime_id_pool ids;
+    ids.add(uuid);
 
     auto uuid2 = generate_random_uuid();
     ids.add(uuid2);
@@ -57,7 +56,8 @@ TEST(RuntimeIDPool, RemoveCurrent)
 TEST(RuntimeIDPool, RemoveLastAndAdd)
 {
     auto uuid = generate_random_uuid();
-    runtime_id_pool ids{uuid};
+    runtime_id_pool ids;
+    ids.add(uuid);
     ids.remove(uuid);
 
     auto uuid2 = generate_random_uuid();
@@ -69,7 +69,8 @@ TEST(RuntimeIDPool, RemoveLastAndAdd)
 TEST(RuntimeIDPool, RemoveAddEmptyAndGet)
 {
     auto uuid = generate_random_uuid();
-    runtime_id_pool ids{uuid};
+    runtime_id_pool ids;
+    ids.add(uuid);
     ids.remove(uuid);
     ids.add("");
 
@@ -80,7 +81,8 @@ TEST(RuntimeIDPool, RemoveDuplicateAndGet)
 {
     auto uuid = generate_random_uuid();
     auto uuid2 = generate_random_uuid();
-    runtime_id_pool ids{uuid};
+    runtime_id_pool ids;
+    ids.add(uuid);
     ids.add(uuid);
     ids.add(uuid);
     ids.add(uuid2);
@@ -94,7 +96,8 @@ TEST(RuntimeIDPool, RemoveAllDuplicatesAndGet)
 {
     auto uuid = generate_random_uuid();
     auto uuid2 = generate_random_uuid();
-    runtime_id_pool ids{uuid};
+    runtime_id_pool ids;
+    ids.add(uuid);
     ids.add(uuid);
     ids.add(uuid);
     ids.add(uuid2);
@@ -109,7 +112,8 @@ TEST(RuntimeIDPool, RemoveAllDuplicatesAndGet)
 TEST(RuntimeIDPool, AddManyAndRemove)
 {
     auto uuid = generate_random_uuid();
-    runtime_id_pool ids{uuid};
+    runtime_id_pool ids;
+    ids.add(uuid);
 
     std::array<std::string, 20> uuid_array;
 


### PR DESCRIPTION
### Description

Small fix for an issue which causes the runtime ID to be duplicated due to the multiset initialisation.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


