### PR TITLE
Improve tracer state detection

### DIFF
--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -444,8 +444,6 @@ __thread void *unspecnull TSRMLS_CACHE = NULL;
 
 static void _check_enabled()
 {
-    /*mlog(dd_log_error, "Tracer enabled? %s", get_DD_TRACE_ENABLED() ? "true" :
-     * "false");*/
     if (!get_global_DD_APPSEC_TESTING() &&
         (!get_DD_TRACE_ENABLED() || strcmp(sapi_module.name, "cli") == 0 ||
             (sapi_module.phpinfo_as_text != 0))) {

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -444,9 +444,11 @@ __thread void *unspecnull TSRMLS_CACHE = NULL;
 
 static void _check_enabled()
 {
+    /*mlog(dd_log_error, "Tracer enabled? %s", get_DD_TRACE_ENABLED() ? "true" :
+     * "false");*/
     if (!get_global_DD_APPSEC_TESTING() &&
-        (!dd_trace_enabled() || strcmp(sapi_module.name, "cli") == 0 ||
-            sapi_module.phpinfo_as_text)) {
+        (!get_DD_TRACE_ENABLED() || strcmp(sapi_module.name, "cli") == 0 ||
+            (sapi_module.phpinfo_as_text != 0))) {
         DDAPPSEC_G(enabled_by_configuration) = DISABLED;
     } else if (!dd_is_config_using_default(DDAPPSEC_CONFIG_DD_APPSEC_ENABLED)) {
         DDAPPSEC_G(enabled_by_configuration) =

--- a/src/extension/ddtrace.h
+++ b/src/extension/ddtrace.h
@@ -17,7 +17,10 @@ void dd_trace_shutdown(void);
 void dd_trace_rinit(void);
 // Returns the tracer version
 const char *nullable dd_trace_version(void);
+// This function should only be used in RINIT
 bool dd_trace_enabled(void);
+// This function should be used before loading tracer symbols
+bool dd_trace_loaded(void);
 
 // increases the refcount of tag, but not value (like zval_hash_add)
 // however, it destroy value if the operation fails (unlike zval_hash_add)

--- a/src/extension/user_tracking.c
+++ b/src/extension/user_tracking.c
@@ -43,7 +43,7 @@ static PHP_FUNCTION(set_user_wrapper)
 
 void dd_user_tracking_startup(void)
 {
-    if (!dd_trace_enabled()) {
+    if (!dd_trace_loaded()) {
         return;
     }
     zend_function *set_user = zend_hash_str_find_ptr(


### PR DESCRIPTION
### Description

This PR fixes two different problems:

- Distinguishing between the tracer being enabled and being loaded, the former shouldn't prevent appsec from loading symbols while the latter should.
- Obtaining the correct tracer enabled state during the request lifecycle.

Related ticket: APPSEC-11407
### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


