### PR TITLE
Always update enabled status on RINIT

### DIFF
--- a/src/extension/configuration.h
+++ b/src/extension/configuration.h
@@ -31,7 +31,7 @@ extern bool runtime_config_first_init;
 
 // clang-format off
 #define DD_CONFIGURATION \
-    SYSCFG(BOOL, DD_APPSEC_ENABLED, "false")                                                                                          \
+    CONFIG(BOOL, DD_APPSEC_ENABLED, "false")                                                                                          \
     SYSCFG(STRING, DD_APPSEC_RULES, "")                                                                                               \
     SYSCFG(CUSTOM(uint64_t), DD_APPSEC_WAF_TIMEOUT, "10000", .parser = _parse_uint64)                                                 \
     SYSCFG(CUSTOM(uint32_t), DD_APPSEC_TRACE_RATE_LIMIT, "100", .parser = _parse_uint32)                                              \

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -438,7 +438,6 @@ __thread void *unspecnull TSRMLS_CACHE = NULL;
 
 static void _check_enabled()
 {
-    mlog(dd_log_error, "STATE OF DDTRACE %s", get_DD_TRACE_ENABLED() ? "true" : "false");
     if (!get_global_DD_APPSEC_TESTING() &&
         (!dd_trace_enabled() || strcmp(sapi_module.name, "cli") == 0 ||
             (sapi_module.phpinfo_as_text != 0))) {

--- a/src/extension/ddappsec.c
+++ b/src/extension/ddappsec.c
@@ -247,13 +247,7 @@ static PHP_RINIT_FUNCTION(ddappsec)
     pthread_once(&_rinit_once_control, _rinit_once);
     zai_config_rinit();
 
-    //_check_enabled should be run only once. However, pthread_once approach
-    // does not work with ZTS.
-    if (DDAPPSEC_G(enabled) == NOT_CONFIGURED) {
-        mlog_g(
-            dd_log_trace, "Enabled not configured, computing enabled status");
-        _check_enabled();
-    }
+    _check_enabled();
 
     if (DDAPPSEC_G(enabled_by_configuration) == DISABLED) {
         return SUCCESS;
@@ -444,13 +438,14 @@ __thread void *unspecnull TSRMLS_CACHE = NULL;
 
 static void _check_enabled()
 {
+    mlog(dd_log_error, "STATE OF DDTRACE %s", get_DD_TRACE_ENABLED() ? "true" : "false");
     if (!get_global_DD_APPSEC_TESTING() &&
-        (!get_DD_TRACE_ENABLED() || strcmp(sapi_module.name, "cli") == 0 ||
+        (!dd_trace_enabled() || strcmp(sapi_module.name, "cli") == 0 ||
             (sapi_module.phpinfo_as_text != 0))) {
         DDAPPSEC_G(enabled_by_configuration) = DISABLED;
     } else if (!dd_is_config_using_default(DDAPPSEC_CONFIG_DD_APPSEC_ENABLED)) {
         DDAPPSEC_G(enabled_by_configuration) =
-            get_global_DD_APPSEC_ENABLED() ? ENABLED : DISABLED;
+            get_DD_APPSEC_ENABLED() ? ENABLED : DISABLED;
     } else {
         DDAPPSEC_G(enabled_by_configuration) = NOT_CONFIGURED;
     };

--- a/tests/extension/bad_env_ini.phpt
+++ b/tests/extension/bad_env_ini.phpt
@@ -14,7 +14,6 @@ extension=ddtrace.so
 var_dump(ini_get("datadog.appsec.log_level"));
 ?>
 --EXPECTF--
-Notice: %s: [ddappsec] Enabled not configured, computing enabled status in Unknown on line 0
 string(5) "trace"
 
 Notice: PHP Shutdown: [ddappsec] Shutting down the file logging in Unknown on line 0


### PR DESCRIPTION
### Description

In order to properly support `.htaccess` with any configuration (appsec enabled on, off or not set), the enabled status of needs to be updated on every RINIT.

Note that this doesn't fix the update of variables shared with the tracer when they are modified through `.htaccess`.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


