### PR TITLE
Release v0.14.2 and upgrade tracer to fix ZAI config handling for .htaccess with php-fpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog AppSec for PHP Release
 
+### v0.14.2
+
+#### Fixes
+- ([#307](https://github.com/DataDog/dd-appsec-php/pull/307)) Always update enabled status on RINIT
+- ([dd-trace-php/#2298](https://github.com/DataDog/dd-trace-php/pull/2298)) Fix ZAI config handling for .htaccess with php-fpm
+
 ### v0.14.1
 
 #### Fixes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ HunterGate(
     URL "https://github.com/cpp-pm/hunter/archive/v0.23.314.tar.gz"
     SHA1 "95c47c92f68edb091b5d6d18924baabe02a6962a")
 
-project(ddappsec VERSION 0.14.1)
+project(ddappsec VERSION 0.14.2)
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
### Description

A fix was introduced in the latest version of zai config to ensure shared `.htaccess` values are available to all extensions.

This PR also includes the release v0.14.2 changes.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Readiness checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
- [ ] All new source files include the required notice

### Release checklist

- [ ] The CHANGELOG.md has been updated


